### PR TITLE
feat: http connection handling enhancement

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -77,6 +77,18 @@
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
         </dependency>
+
+        <!-- Test dependencies -->
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/src/main/java/io/gravitee/connector/http/AbstractHttpConnection.java
+++ b/src/main/java/io/gravitee/connector/http/AbstractHttpConnection.java
@@ -37,7 +37,7 @@ public abstract class AbstractHttpConnection<E extends HttpEndpoint> extends io.
         int port,
         String host,
         String uri,
-        Handler<Void> connectionHandler,
+        Handler<AbstractHttpConnection> connectionHandler,
         Handler<Void> tracker
     );
 

--- a/src/main/java/io/gravitee/connector/http/AbstractHttpConnector.java
+++ b/src/main/java/io/gravitee/connector/http/AbstractHttpConnector.java
@@ -141,7 +141,7 @@ public abstract class AbstractHttpConnector<E extends HttpEndpoint> extends Abst
                 port,
                 url.getHost(),
                 (url.getQuery() == null) ? url.getPath() : url.getPath() + URI_QUERY_DELIMITER_CHAR + url.getQuery(),
-                connect -> connectionHandler.handle(connection),
+                connectionHandler::handle,
                 result -> requestTracker.decrementAndGet()
             );
         } catch (MalformedURLException ex) {

--- a/src/main/java/io/gravitee/connector/http/HttpConnection.java
+++ b/src/main/java/io/gravitee/connector/http/HttpConnection.java
@@ -83,7 +83,14 @@ public class HttpConnection<T extends HttpResponse> extends AbstractHttpConnecti
     }
 
     @Override
-    public void connect(HttpClient httpClient, int port, String host, String uri, Handler<Void> connectionHandler, Handler<Void> tracker) {
+    public void connect(
+        HttpClient httpClient,
+        int port,
+        String host,
+        String uri,
+        Handler<AbstractHttpConnection> connectionHandler,
+        Handler<Void> tracker
+    ) {
         // Remove HOP-by-HOP headers
         for (CharSequence header : HOP_HEADERS) {
             request.headers().remove(header.toString());
@@ -114,7 +121,7 @@ public class HttpConnection<T extends HttpResponse> extends AbstractHttpConnecti
                                 }
                             }
                         );
-                        connectionHandler.handle(null);
+                        connectionHandler.handle(HttpConnection.this);
                     } else {
                         connectionHandler.handle(null);
                         handleException(event.cause());

--- a/src/main/java/io/gravitee/connector/http/ws/WebSocketConnection.java
+++ b/src/main/java/io/gravitee/connector/http/ws/WebSocketConnection.java
@@ -62,7 +62,14 @@ public class WebSocketConnection extends AbstractHttpConnection<HttpEndpoint> {
     }
 
     @Override
-    public void connect(HttpClient httpClient, int port, String host, String uri, Handler<Void> connectionHandler, Handler<Void> tracker) {
+    public void connect(
+        HttpClient httpClient,
+        int port,
+        String host,
+        String uri,
+        Handler<AbstractHttpConnection> connectionHandler,
+        Handler<Void> tracker
+    ) {
         // Remove hop-by-hop headers.
         for (CharSequence header : WS_HOP_HEADERS) {
             wsProxyRequest.headers().remove(header);
@@ -156,7 +163,7 @@ public class WebSocketConnection extends AbstractHttpConnection<HttpEndpoint> {
                                             }
                                         );
 
-                                    connectionHandler.handle(null);
+                                    connectionHandler.handle(WebSocketConnection.this);
 
                                     // Tell the reactor that the request has been handled by the HTTP client
                                     sendToClient(new SwitchProtocolProxyResponse());

--- a/src/test/java/io/gravitee/connector/http/HttpConnectionTest.java
+++ b/src/test/java/io/gravitee/connector/http/HttpConnectionTest.java
@@ -1,0 +1,88 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.connector.http;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+import io.gravitee.common.http.HttpHeaders;
+import io.gravitee.common.http.HttpMethod;
+import io.gravitee.connector.api.Response;
+import io.gravitee.connector.http.endpoint.HttpClientOptions;
+import io.gravitee.connector.http.endpoint.HttpEndpoint;
+import io.gravitee.gateway.api.handler.Handler;
+import io.gravitee.gateway.api.proxy.ProxyRequest;
+import io.gravitee.reporter.api.http.Metrics;
+import io.vertx.core.Future;
+import io.vertx.core.http.HttpClient;
+import io.vertx.core.http.HttpClientRequest;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+/**
+ * @author GraviteeSource Team
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class HttpConnectionTest {
+
+    @Mock
+    private ProxyRequest proxyRequest;
+
+    @Mock
+    private HttpEndpoint endpoint;
+
+    @Mock
+    private Handler<Response> responseHandler;
+
+    @Mock
+    private Handler<AbstractHttpConnection> connectionHandler;
+
+    @Mock
+    private HttpClient httpClient;
+
+    private HttpConnection httpConnection;
+
+    @Before
+    public void setupMockedHttpConnection() {
+        when(proxyRequest.headers()).thenReturn(new HttpHeaders());
+        when(proxyRequest.method()).thenReturn(HttpMethod.CONNECT);
+        when(proxyRequest.metrics()).thenReturn(Metrics.on(123L).build());
+        when(endpoint.getHttpClientOptions()).thenReturn(new HttpClientOptions());
+        httpConnection = new HttpConnection(endpoint, proxyRequest);
+        httpConnection.responseHandler(responseHandler);
+    }
+
+    @Test
+    public void connection_handler_is_triggered_with_connection_on_connection_success() {
+        when(httpClient.request(any())).thenReturn(Future.succeededFuture(mock(HttpClientRequest.class)));
+
+        httpConnection.connect(httpClient, 80, "test.hostname", "https://test", connectionHandler, mock(Handler.class));
+
+        verify(connectionHandler, times(1)).handle(httpConnection);
+    }
+
+    @Test
+    public void connection_handler_is_triggered_with_null_on_connection_failure() {
+        when(httpClient.request(any())).thenReturn(Future.failedFuture("test failed connection"));
+
+        httpConnection.connect(httpClient, 80, "test.hostname", "https://test", connectionHandler, mock(Handler.class));
+
+        verify(connectionHandler, times(1)).handle(null);
+    }
+}


### PR DESCRIPTION
:warning: Keep as draft as we not checked all the impacts on AbstractHttpConnector.request() caller, getting a null connection on error :warning: 

**Issue**

https://github.com/gravitee-io/issues/issues/6025

**Description**

feat: http connection handling enhancement

This makes AbstractHttpProxyConnection trigger the connection handler with connection on success, or null if connection failed.
That permits to distinguish behaviors when connection succeeeds or fails.
