### PR TITLE
fix: don't use Accept-Encoding header from client

### DIFF
--- a/src/main/java/io/gravitee/connector/http/AbstractHttpConnector.java
+++ b/src/main/java/io/gravitee/connector/http/AbstractHttpConnector.java
@@ -15,6 +15,7 @@
  */
 package io.gravitee.connector.http;
 
+import io.gravitee.common.http.HttpHeader;
 import io.gravitee.common.http.HttpHeaders;
 import io.gravitee.common.util.MultiValueMap;
 import io.gravitee.connector.api.AbstractConnector;
@@ -50,6 +51,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Function;
+import java.util.function.Predicate;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -120,6 +122,8 @@ public abstract class AbstractHttpConnector<E extends HttpEndpoint> extends Abst
             if (endpoint.getHeaders() != null && !endpoint.getHeaders().isEmpty()) {
                 endpoint
                     .getHeaders()
+                    .stream()
+                    .filter(httpHeader -> !httpHeader.getName().equalsIgnoreCase(HttpHeaders.ACCEPT_ENCODING))
                     .forEach(header -> {
                         request.headers().add(header.getName(), header.getValue());
                     });


### PR DESCRIPTION
gravitee-io/issues#6967
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `1.1.1-SNAPSHOT.6967-remove-accept-encoding-client-header`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/connector/gravitee-connector-http/1.1.1-SNAPSHOT.6967-remove-accept-encoding-client-header/gravitee-connector-http-1.1.1-SNAPSHOT.6967-remove-accept-encoding-client-header.zip)
  <!-- Version placeholder end -->
