### PR TITLE
fix: let the API Owner choose the Accept-Encoding

### DIFF
--- a/src/main/java/io/gravitee/connector/http/HttpConnection.java
+++ b/src/main/java/io/gravitee/connector/http/HttpConnection.java
@@ -89,6 +89,9 @@ public class HttpConnection<T extends HttpResponse> extends AbstractHttpConnecti
             request.headers().remove(header.toString());
         }
 
+        // Let the API Owner choose the Accept-Encoding between the gateway and the backend
+        request.headers().remove(io.gravitee.common.http.HttpHeaders.ACCEPT_ENCODING);
+
         Future<HttpClientRequest> request = prepareUpstreamRequest(httpClient, port, host, uri);
         request.onComplete(
             new io.vertx.core.Handler<>() {


### PR DESCRIPTION
gravitee-io/issues#6967
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `1.1.1-SNAPSHOT.6967-remove-accept-encoding-client-header`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/connector/gravitee-connector-http/1.1.1-SNAPSHOT.6967-remove-accept-encoding-client-header/gravitee-connector-http-1.1.1-SNAPSHOT.6967-remove-accept-encoding-client-header.zip)
  <!-- Version placeholder end -->
