### PR TITLE
fix: handle sse client side connection close

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@
 
     <properties>
         <gravitee-bom.version>1.4</gravitee-bom.version>
-        <gravitee-connector-api.version>1.1.0</gravitee-connector-api.version>
+        <gravitee-connector-api.version>1.1.1</gravitee-connector-api.version>
         <!-- Property used by the publication job in CI-->
         <publish-folder-path>graviteeio-apim/plugins/connectors</publish-folder-path>
     </properties>


### PR DESCRIPTION
see https://github.com/gravitee-io/issues/issues/7573
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `1.1.4-fix-handle-client-side-connnection-close-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/connector/gravitee-connector-http/1.1.4-fix-handle-client-side-connnection-close-SNAPSHOT/gravitee-connector-http-1.1.4-fix-handle-client-side-connnection-close-SNAPSHOT.zip)
  <!-- Version placeholder end -->
