### PR TITLE
fix: make the follow redirects ui message more generic

### DIFF
--- a/src/main/resources/schemas/schema-form.json
+++ b/src/main/resources/schemas/schema-form.json
@@ -59,7 +59,7 @@
         },
         "followRedirects": {
           "title": "Follow HTTP redirects",
-          "description": "When the client receives an 301, 302, 303 or 307 status code, it follows the redirection provided by the Location response header",
+          "description": "When the client receives a status code in the range 3xx, it follows the redirection provided by the Location response header",
           "type": "boolean",
           "default": false
         },


### PR DESCRIPTION
The enumeration of the HTTP redirects status code was incomplete
(e.g. the 308 permanent redirect was missing), leading to some
misunderstanding about how the underlying implementation works.

The parameter is forwarded to the Vert.x HTTP client implementation,
which considers any status in the 3xx range as a redirect and handles
it if the `followRedirect` option is set to `true`
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `1.1.5-docs-change-redirect-ui-message-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/connector/gravitee-connector-http/1.1.5-docs-change-redirect-ui-message-SNAPSHOT/gravitee-connector-http-1.1.5-docs-change-redirect-ui-message-SNAPSHOT.zip)
  <!-- Version placeholder end -->
