### PR TITLE
refactor: use common system proxy options factory

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -12,3 +12,13 @@ endif::[]
 == Description
 
 The HTTP connector implements the SME Connector API in order to provide native integration with HTTP Protocol.
+
+== Compatibility with APIM
+
+|===
+|Plugin version | APIM version
+
+|2.x and upper                  | 3.18.x to latest
+|1.1.x and upper                | 3.15.x to 3.17.x
+|1.0.x and upper                | 3.13.x to 3.14.x
+|===

--- a/pom.xml
+++ b/pom.xml
@@ -35,6 +35,7 @@
 
     <properties>
         <gravitee-bom.version>1.4</gravitee-bom.version>
+        <gravitee-common.version>1.26.1</gravitee-common.version>
         <gravitee-connector-api.version>1.1.1</gravitee-connector-api.version>
         <!-- Property used by the publication job in CI-->
         <publish-folder-path>graviteeio-apim/plugins/connectors</publish-folder-path>
@@ -54,6 +55,13 @@
     </dependencyManagement>
 
     <dependencies>
+        <dependency>
+            <groupId>io.gravitee.common</groupId>
+            <artifactId>gravitee-common</artifactId>
+            <version>${gravitee-common.version}</version>
+            <scope>provided</scope>
+        </dependency>
+
         <dependency>
             <groupId>io.gravitee.connector</groupId>
             <artifactId>gravitee-connector-api</artifactId>


### PR DESCRIPTION
see https://github.com/gravitee-io/issues/issues/7739
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `2.0.0-refactor-use-commong-proxy-options-factory-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/connector/gravitee-connector-http/2.0.0-refactor-use-commong-proxy-options-factory-SNAPSHOT/gravitee-connector-http-2.0.0-refactor-use-commong-proxy-options-factory-SNAPSHOT.zip)
  <!-- Version placeholder end -->
