### PR TITLE
fix: propagate multi value header properly

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -93,6 +93,11 @@
             <scope>test</scope>
         </dependency>
 
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/src/main/java/io/gravitee/connector/http/HttpConnection.java
+++ b/src/main/java/io/gravitee/connector/http/HttpConnection.java
@@ -303,7 +303,12 @@ public class HttpConnection<T extends HttpResponse> extends AbstractHttpConnecti
         }
 
         // Copy headers to upstream
-        request.headers().forEach(entry -> httpClientRequest.putHeader(entry.getKey(), entry.getValue()));
+        request
+            .headers()
+            .names()
+            .forEach(name -> {
+                httpClientRequest.headers().add(name, request.headers().getAll(name));
+            });
     }
 
     @Override

--- a/src/test/java/io/gravitee/connector/http/HttpConnectionTest.java
+++ b/src/test/java/io/gravitee/connector/http/HttpConnectionTest.java
@@ -1,0 +1,120 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.connector.http;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.gravitee.common.http.HttpMethod;
+import io.gravitee.connector.http.endpoint.HttpClientOptions;
+import io.gravitee.connector.http.endpoint.HttpEndpoint;
+import io.gravitee.connector.http.stub.DummyHttpClientRequest;
+import io.gravitee.gateway.api.http.HttpHeaderNames;
+import io.gravitee.gateway.api.http.HttpHeaders;
+import io.gravitee.gateway.api.proxy.ProxyRequest;
+import io.vertx.core.AsyncResult;
+import io.vertx.core.Future;
+import io.vertx.core.Handler;
+import io.vertx.core.MultiMap;
+import io.vertx.core.Vertx;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.core.http.HttpClient;
+import io.vertx.core.http.HttpClientRequest;
+import io.vertx.core.http.HttpClientResponse;
+import io.vertx.core.http.HttpVersion;
+import io.vertx.core.http.StreamPriority;
+import io.vertx.core.http.impl.HttpClientRequestBase;
+import java.io.IOException;
+import java.net.ServerSocket;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.assertj.core.api.Assertions;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.junit.MockitoJUnitRunner;
+
+/**
+ * @author Yann TAVERNIER (yann.tavernier at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class HttpConnectionTest {
+
+    public static final String FIRST_HEADER = "First-Header";
+    public static final String SECOND_HEADER = "Second-Header";
+    public static final String FIRST_HEADER_VALUE_1 = "first-header-value-1";
+    public static final String FIRST_HEADER_VALUE_2 = "first-header-value-2";
+    public static final String SECOND_HEADER_VALUE = "second-header-value";
+
+    private HttpConnection<HttpResponse> cut;
+
+    @Mock
+    private HttpEndpoint endpoint;
+
+    @Mock
+    private ProxyRequest request;
+
+    @Mock
+    private HttpClient client;
+
+    @Spy
+    private HttpClientRequest httpClientRequest = new DummyHttpClientRequest();
+
+    private HttpHeaders headers;
+
+    @Before
+    public void setUp() {
+        cut = new HttpConnection<>(endpoint, request);
+
+        headers = HttpHeaders.create();
+        headers.add(FIRST_HEADER, FIRST_HEADER_VALUE_1);
+        headers.add(FIRST_HEADER, FIRST_HEADER_VALUE_2);
+        headers.add(SECOND_HEADER, SECOND_HEADER_VALUE);
+        headers.add(HttpHeaderNames.TRANSFER_ENCODING, "transfer_encoding");
+
+        when(request.headers()).thenReturn(headers);
+        when(request.method()).thenReturn(HttpMethod.GET);
+
+        when(endpoint.getHttpClientOptions()).thenReturn(new HttpClientOptions());
+        when(client.request(any())).thenReturn(Future.succeededFuture(httpClientRequest));
+    }
+
+    @Test
+    public void shouldWriteUpstreamHeaders() {
+        cut.connect(client, getAvailablePort(), "host", "/", unused -> {}, result -> new AtomicInteger(1).decrementAndGet());
+
+        cut.writeUpstreamHeaders();
+
+        assertThat(headers.contains(io.vertx.core.http.HttpHeaders.TRANSFER_ENCODING)).isFalse();
+        assertThat(httpClientRequest.headers().getAll(SECOND_HEADER)).hasSize(1).containsExactly(SECOND_HEADER_VALUE);
+
+        assertThat(httpClientRequest.headers().getAll(FIRST_HEADER)).hasSize(2).containsExactly(FIRST_HEADER_VALUE_1, FIRST_HEADER_VALUE_2);
+    }
+
+    private int getAvailablePort() {
+        try (ServerSocket socket = new ServerSocket(0)) {
+            return socket.getLocalPort();
+        } catch (IOException e) {
+            throw new AssertionError(e);
+        }
+    }
+}

--- a/src/test/java/io/gravitee/connector/http/stub/DummyHttpClientRequest.java
+++ b/src/test/java/io/gravitee/connector/http/stub/DummyHttpClientRequest.java
@@ -1,0 +1,294 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.connector.http.stub;
+
+import io.vertx.core.AsyncResult;
+import io.vertx.core.Future;
+import io.vertx.core.Handler;
+import io.vertx.core.MultiMap;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.core.http.HttpClientRequest;
+import io.vertx.core.http.HttpClientResponse;
+import io.vertx.core.http.HttpVersion;
+import io.vertx.core.http.StreamPriority;
+import io.vertx.core.http.impl.headers.HeadersMultiMap;
+
+/**
+ * Dummy implementation of {@link HttpClientRequest} for testing purpose
+ * @author Yann TAVERNIER (yann.tavernier at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public class DummyHttpClientRequest implements HttpClientRequest {
+
+    private final MultiMap headers;
+
+    public DummyHttpClientRequest() {
+        this.headers = new HeadersMultiMap();
+    }
+
+    @Override
+    public HttpClientRequest exceptionHandler(Handler<Throwable> handler) {
+        return null;
+    }
+
+    @Override
+    public Future<Void> write(Buffer data) {
+        return null;
+    }
+
+    @Override
+    public void write(Buffer data, Handler<AsyncResult<Void>> handler) {}
+
+    @Override
+    public HttpClientRequest setWriteQueueMaxSize(int maxSize) {
+        return null;
+    }
+
+    @Override
+    public boolean writeQueueFull() {
+        return false;
+    }
+
+    @Override
+    public HttpClientRequest drainHandler(Handler<Void> handler) {
+        return null;
+    }
+
+    @Override
+    public HttpClientRequest setHost(String host) {
+        return null;
+    }
+
+    @Override
+    public String getHost() {
+        return null;
+    }
+
+    @Override
+    public HttpClientRequest setPort(int port) {
+        return null;
+    }
+
+    @Override
+    public int getPort() {
+        return 0;
+    }
+
+    @Override
+    public HttpClientRequest setFollowRedirects(boolean followRedirects) {
+        return null;
+    }
+
+    @Override
+    public HttpClientRequest setMaxRedirects(int maxRedirects) {
+        return null;
+    }
+
+    @Override
+    public HttpClientRequest setChunked(boolean chunked) {
+        return null;
+    }
+
+    @Override
+    public boolean isChunked() {
+        return false;
+    }
+
+    @Override
+    public io.vertx.core.http.HttpMethod getMethod() {
+        return null;
+    }
+
+    @Override
+    public HttpClientRequest setMethod(io.vertx.core.http.HttpMethod method) {
+        return null;
+    }
+
+    @Override
+    public String absoluteURI() {
+        return null;
+    }
+
+    @Override
+    public String getURI() {
+        return null;
+    }
+
+    @Override
+    public HttpClientRequest setURI(String uri) {
+        return null;
+    }
+
+    @Override
+    public String path() {
+        return null;
+    }
+
+    @Override
+    public String query() {
+        return null;
+    }
+
+    @Override
+    public MultiMap headers() {
+        return headers;
+    }
+
+    @Override
+    public HttpClientRequest putHeader(String name, String value) {
+        this.headers.set(name, value);
+        return this;
+    }
+
+    @Override
+    public HttpClientRequest putHeader(CharSequence name, CharSequence value) {
+        this.headers.set(name, value);
+        return this;
+    }
+
+    @Override
+    public HttpClientRequest putHeader(String name, Iterable<String> values) {
+        this.headers.set(name, values);
+        return this;
+    }
+
+    @Override
+    public HttpClientRequest putHeader(CharSequence name, Iterable<CharSequence> values) {
+        this.headers.set(name, values);
+        return this;
+    }
+
+    @Override
+    public HttpVersion version() {
+        return null;
+    }
+
+    @Override
+    public Future<Void> write(String chunk) {
+        return null;
+    }
+
+    @Override
+    public void write(String chunk, Handler<AsyncResult<Void>> handler) {}
+
+    @Override
+    public Future<Void> write(String chunk, String enc) {
+        return null;
+    }
+
+    @Override
+    public void write(String chunk, String enc, Handler<AsyncResult<Void>> handler) {}
+
+    @Override
+    public HttpClientRequest continueHandler(Handler<Void> handler) {
+        return null;
+    }
+
+    @Override
+    public Future<Void> sendHead() {
+        return null;
+    }
+
+    @Override
+    public HttpClientRequest sendHead(Handler<AsyncResult<Void>> completionHandler) {
+        return null;
+    }
+
+    @Override
+    public void connect(Handler<AsyncResult<HttpClientResponse>> handler) {}
+
+    @Override
+    public Future<HttpClientResponse> connect() {
+        return null;
+    }
+
+    @Override
+    public HttpClientRequest response(Handler<AsyncResult<HttpClientResponse>> handler) {
+        return null;
+    }
+
+    @Override
+    public Future<HttpClientResponse> response() {
+        return null;
+    }
+
+    @Override
+    public Future<Void> end(String chunk) {
+        return null;
+    }
+
+    @Override
+    public void end(String chunk, Handler<AsyncResult<Void>> handler) {}
+
+    @Override
+    public Future<Void> end(String chunk, String enc) {
+        return null;
+    }
+
+    @Override
+    public void end(String chunk, String enc, Handler<AsyncResult<Void>> handler) {}
+
+    @Override
+    public Future<Void> end(Buffer chunk) {
+        return null;
+    }
+
+    @Override
+    public void end(Buffer chunk, Handler<AsyncResult<Void>> handler) {}
+
+    @Override
+    public Future<Void> end() {
+        return null;
+    }
+
+    @Override
+    public void end(Handler<AsyncResult<Void>> handler) {}
+
+    @Override
+    public HttpClientRequest setTimeout(long timeoutMs) {
+        return null;
+    }
+
+    @Override
+    public HttpClientRequest pushHandler(Handler<HttpClientRequest> handler) {
+        return null;
+    }
+
+    @Override
+    public boolean reset(long code) {
+        return false;
+    }
+
+    @Override
+    public boolean reset(long code, Throwable cause) {
+        return false;
+    }
+
+    @Override
+    public io.vertx.core.http.HttpConnection connection() {
+        return null;
+    }
+
+    @Override
+    public HttpClientRequest writeCustomFrame(int type, int flags, Buffer payload) {
+        return null;
+    }
+
+    @Override
+    public StreamPriority getStreamPriority() {
+        return null;
+    }
+}


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/7812

**Description**

Working on the backward compatibility of HTTP Header, we detected that multivalued headers were not propagated to the backend. Only one value was sent.

**Fix**

This fix simply replace the way we pushing request headers to upstream: we do not rely anymore on HttpHeaders' iterator which returns the first value for a given key, but we copy the collection of value for each key.
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `1.1.6-issues-7812-retro-headers-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/connector/gravitee-connector-http/1.1.6-issues-7812-retro-headers-SNAPSHOT/gravitee-connector-http-1.1.6-issues-7812-retro-headers-SNAPSHOT.zip)
  <!-- Version placeholder end -->
