### PR TITLE
fix: restore HTTP headers backward compatibility

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@
 
     <properties>
         <gravitee-bom.version>1.4</gravitee-bom.version>
-        <gravitee-connector-api.version>1.1.1</gravitee-connector-api.version>
+        <gravitee-connector-api.version>1.1.2</gravitee-connector-api.version>
         <!-- Property used by the publication job in CI-->
         <publish-folder-path>graviteeio-apim/plugins/connectors</publish-folder-path>
     </properties>
@@ -98,6 +98,7 @@
             <artifactId>assertj-core</artifactId>
             <scope>test</scope>
         </dependency>
+
     </dependencies>
 
     <build>

--- a/src/main/java/io/gravitee/connector/http/vertx/VertxHttpHeaders.java
+++ b/src/main/java/io/gravitee/connector/http/vertx/VertxHttpHeaders.java
@@ -15,18 +15,26 @@
  */
 package io.gravitee.connector.http.vertx;
 
+import io.gravitee.common.util.LinkedCaseInsensitiveMap;
+import io.gravitee.common.util.MultiValueMap;
+import io.gravitee.gateway.api.http.DefaultHttpHeaders;
 import io.gravitee.gateway.api.http.HttpHeaders;
 import io.vertx.core.MultiMap;
+import io.vertx.core.http.impl.headers.HeadersMultiMap;
+import java.util.Collection;
+import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 /**
+ * * Implements {@link MultiValueMap<String,String>} for backward compatibility due to the changes to Headers in 3.15.
  * @author David BRASSELY (david.brassely at graviteesource.com)
  * @author GraviteeSource Team
  */
-public class VertxHttpHeaders implements HttpHeaders {
+public class VertxHttpHeaders implements HttpHeaders, MultiValueMap<String, String> {
 
     private final MultiMap headers;
 
@@ -102,5 +110,126 @@ public class VertxHttpHeaders implements HttpHeaders {
     @Override
     public Iterator<Map.Entry<String, String>> iterator() {
         return headers.iterator();
+    }
+
+    @Override
+    public Map<String, String> toSingleValueMap() {
+        return HttpHeaders.super.toSingleValueMap();
+    }
+
+    @Override
+    public boolean containsAllKeys(Collection<String> names) {
+        return HttpHeaders.super.containsAllKeys(names);
+    }
+
+    @Override
+    public boolean containsKey(Object key) {
+        return contains(String.valueOf(key));
+    }
+
+    @Override
+    public boolean containsValue(Object value) {
+        return entrySet().stream().anyMatch(entry -> value.equals(entry.getValue()));
+    }
+
+    /**
+     * @see LinkedCaseInsensitiveMap#get(Object)
+     * Contrary to {@link DefaultHttpHeaders#get(CharSequence)}, the list of values is returned, not only the first element
+     */
+    @Override
+    public List<String> get(Object key) {
+        return headers.getAll(String.valueOf(key));
+    }
+
+    /**
+     * @see HashMap#putVal(int, Object, Object, boolean, boolean), returns the previous value if present, else null.
+     */
+    @Override
+    public List<String> put(String key, List<String> value) {
+        final List<String> previousValues = headers.getAll(key);
+        for (int i = 0; i < value.size(); i++) {
+            // For the first element, we need to use set to override previous value, then we use add to add new ones.
+            if (i == 0) {
+                headers.set(key, value.get(i));
+            } else {
+                headers.add(key, value.get(i));
+            }
+        }
+        return previousValues.isEmpty() ? null : previousValues;
+    }
+
+    /**
+     * @see HashMap#remove(Object), returns the previous value (can bee {@code null}) associated with {@code key} or null if none.
+     */
+    @Override
+    public List<String> remove(Object key) {
+        final List<String> previousValues = headers.getAll(String.valueOf(key));
+        headers.remove(String.valueOf(key));
+        return previousValues;
+    }
+
+    @Override
+    public void putAll(Map<? extends String, ? extends List<String>> map) {
+        final MultiMap multimap = HeadersMultiMap.headers();
+
+        // Flatten the Map<String, List<String>> to be able to add each entry one by one to a new Multimap object
+        map
+            .entrySet()
+            .stream()
+            .flatMap(entry -> entry.getValue().stream().map(v -> Map.entry(entry.getKey(), v)))
+            .forEach(entry -> multimap.add(entry.getKey(), entry.getValue()));
+
+        headers.setAll(multimap);
+    }
+
+    @Override
+    public Set<String> keySet() {
+        return headers.entries().stream().map(Entry::getKey).collect(Collectors.toSet());
+    }
+
+    @Override
+    public Collection<List<String>> values() {
+        return headers
+            .entries()
+            .stream()
+            .collect(Collectors.groupingBy(Entry::getKey))
+            .values()
+            .stream()
+            .map(entries -> entries.stream().map(Entry::getValue).collect(Collectors.toList()))
+            .collect(Collectors.toList());
+    }
+
+    @Override
+    public Set<Entry<String, List<String>>> entrySet() {
+        return headers
+            .entries()
+            .stream()
+            .collect(Collectors.groupingBy(Entry::getKey))
+            .entrySet()
+            .stream()
+            .map(entry -> Map.entry(entry.getKey(), entry.getValue().stream().map(Entry::getValue).collect(Collectors.toList())))
+            .collect(Collectors.toSet());
+    }
+
+    @Override
+    public String getFirst(String header) {
+        return this.headers.get(header);
+    }
+
+    @Override
+    public void add(String name, String value) {
+        headers.add(name, value);
+    }
+
+    @Override
+    public void set(String name, String value) {
+        this.headers.set(name, value);
+    }
+
+    @Override
+    public void setAll(Map<String, String> values) {
+        for (Entry<String, String> entry : values.entrySet()) {
+            set(entry.getKey(), entry.getValue());
+        }
     }
 }

--- a/src/test/java/io/gravitee/connector/http/vertx/VertxHttpHeadersTest.java
+++ b/src/test/java/io/gravitee/connector/http/vertx/VertxHttpHeadersTest.java
@@ -1,0 +1,284 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.connector.http.vertx;
+
+import static io.gravitee.gateway.api.http.HttpHeaderNames.ACCEPT_LANGUAGE;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.gravitee.gateway.api.http.DefaultHttpHeaders;
+import io.gravitee.gateway.api.http.HttpHeaders;
+import io.vertx.core.http.impl.headers.HeadersMultiMap;
+import java.util.List;
+import java.util.Map;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * @author Yann TAVERNIER (yann.tavernier at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public class VertxHttpHeadersTest {
+
+    public static final String FIRST_HEADER = "First-Header";
+    public static final String SECOND_HEADER = "Second-Header";
+    public static final String FIRST_HEADER_VALUE_1 = "first-header-value-1";
+    public static final String FIRST_HEADER_VALUE_2 = "first-header-value-2";
+    public static final String SECOND_HEADER_VALUE = "second-header-value";
+    private VertxHttpHeaders cut;
+
+    private DefaultHttpHeaders defaultHttpHeaders;
+
+    @Before
+    public void setUp() {
+        cut = new VertxHttpHeaders(HeadersMultiMap.headers());
+        cut.add(FIRST_HEADER, FIRST_HEADER_VALUE_1);
+        cut.add(FIRST_HEADER, FIRST_HEADER_VALUE_2);
+        cut.add(SECOND_HEADER, SECOND_HEADER_VALUE);
+
+        // Tests will be also done on DefaultHttpHeaders to verify there is no divergence between both implementations.
+        defaultHttpHeaders = (DefaultHttpHeaders) HttpHeaders.create(cut);
+    }
+
+    @Test
+    public void shouldConvertToSingleValueMap() {
+        final Map<String, String> result = cut.toSingleValueMap();
+        assertThat(result).containsEntry(FIRST_HEADER, FIRST_HEADER_VALUE_1).containsEntry(SECOND_HEADER, SECOND_HEADER_VALUE);
+
+        // In case of multiple values for one header name, this conversion is only taking the first value
+        assertThat(result.values()).doesNotContain(FIRST_HEADER_VALUE_2);
+
+        final Map<String, String> defaultHttpHeadersResult = defaultHttpHeaders.toSingleValueMap();
+        assertThat(result).isEqualTo(defaultHttpHeadersResult);
+    }
+
+    @Test
+    public void shouldContainAllKeys() {
+        assertThat(cut.containsAllKeys(List.of())).isTrue();
+        assertThat(defaultHttpHeaders.containsAllKeys(List.of())).isTrue();
+
+        assertThat(cut.containsAllKeys(List.of(FIRST_HEADER))).isTrue();
+        assertThat(defaultHttpHeaders.containsAllKeys(List.of(FIRST_HEADER))).isTrue();
+
+        assertThat(cut.containsAllKeys(List.of(FIRST_HEADER, SECOND_HEADER))).isTrue();
+        assertThat(defaultHttpHeaders.containsAllKeys(List.of(FIRST_HEADER, SECOND_HEADER))).isTrue();
+
+        assertThat(cut.containsAllKeys(List.of(FIRST_HEADER, SECOND_HEADER, ACCEPT_LANGUAGE))).isFalse();
+        assertThat(defaultHttpHeaders.containsAllKeys(List.of(FIRST_HEADER, SECOND_HEADER, ACCEPT_LANGUAGE))).isFalse();
+
+        assertThat(cut.containsAllKeys(List.of(ACCEPT_LANGUAGE))).isFalse();
+        assertThat(defaultHttpHeaders.containsAllKeys(List.of(ACCEPT_LANGUAGE))).isFalse();
+    }
+
+    @Test
+    public void shouldContainKey() {
+        Object key = new Object();
+        assertThat(cut.containsKey(key)).isFalse();
+        assertThat(defaultHttpHeaders.containsKey(key)).isFalse();
+
+        key = FIRST_HEADER;
+        assertThat(cut.containsKey(key)).isTrue();
+        assertThat(defaultHttpHeaders.containsKey(key)).isTrue();
+
+        key = ACCEPT_LANGUAGE;
+        assertThat(cut.containsKey(key)).isFalse();
+        assertThat(defaultHttpHeaders.containsKey(key)).isFalse();
+    }
+
+    @Test
+    public void shouldContainValue() {
+        Object value = new Object();
+        assertThat(cut.containsValue(value)).isFalse();
+        assertThat(defaultHttpHeaders.containsValue(value)).isFalse();
+
+        value = List.of(FIRST_HEADER_VALUE_1, FIRST_HEADER_VALUE_2);
+        assertThat(cut.containsValue(value)).isTrue();
+        assertThat(defaultHttpHeaders.containsValue(value)).isTrue();
+
+        value = List.of(SECOND_HEADER_VALUE);
+        assertThat(cut.containsValue(value)).isTrue();
+        assertThat(defaultHttpHeaders.containsValue(value)).isTrue();
+
+        value = List.of(ACCEPT_LANGUAGE);
+        assertThat(cut.containsValue(value)).isFalse();
+        assertThat(defaultHttpHeaders.containsValue(value)).isFalse();
+    }
+
+    @Test
+    public void shouldGet() {
+        Object key = new Object();
+        assertThat(cut.get(key)).isEmpty();
+        assertThat(defaultHttpHeaders.get(key)).isEmpty();
+
+        key = FIRST_HEADER;
+        assertThat(cut.get(key)).hasSize(2);
+        assertThat(defaultHttpHeaders.get(key)).hasSize(2);
+
+        key = SECOND_HEADER;
+        assertThat(cut.get(key)).hasSize(1);
+        assertThat(defaultHttpHeaders.get(key)).hasSize(1);
+
+        key = ACCEPT_LANGUAGE;
+        assertThat(cut.get(key)).isEmpty();
+        assertThat(defaultHttpHeaders.get(key)).isEmpty();
+    }
+
+    @Test
+    public void shouldPut() {
+        // Putting a new header
+        final List<String> headerTestValues = List.of("test-value1", "test-value2");
+        final List<String> testHeader = cut.put("test", headerTestValues);
+        final List<String> testHeaderFromDefaultHttpHeaders = defaultHttpHeaders.put("test", headerTestValues);
+
+        assertThat(testHeader).isNull();
+        assertThat(testHeaderFromDefaultHttpHeaders).isNull();
+        assertThat(cut.getAll("test")).isEqualTo(headerTestValues);
+        assertThat(defaultHttpHeaders.getAll("test")).isEqualTo(headerTestValues);
+        assertThat(cut.size()).isEqualTo(3);
+        assertThat(defaultHttpHeaders.size()).isEqualTo(3);
+
+        // Putting a header already present in the map
+        final List<String> firstHeaderNewValues = List.of("first-overridden-1", "first-overridden-2", "first-overridden-3");
+        final List<String> firstHeaderOverridden = cut.put(FIRST_HEADER, firstHeaderNewValues);
+        final List<String> firstHeaderOverriddenDefaultHttpHeaders = defaultHttpHeaders.put(FIRST_HEADER, firstHeaderNewValues);
+
+        assertThat(firstHeaderOverridden).hasSize(2).containsExactlyElementsOf(List.of(FIRST_HEADER_VALUE_1, FIRST_HEADER_VALUE_2));
+        assertThat(firstHeaderOverriddenDefaultHttpHeaders)
+            .hasSize(2)
+            .containsExactlyElementsOf(List.of(FIRST_HEADER_VALUE_1, FIRST_HEADER_VALUE_2));
+        assertThat(cut.getAll(FIRST_HEADER)).containsExactlyElementsOf(firstHeaderNewValues);
+        assertThat(defaultHttpHeaders.getAll(FIRST_HEADER)).containsExactlyElementsOf(firstHeaderNewValues);
+    }
+
+    @Test
+    public void shouldRemove() {
+        final HttpHeaders headers = cut.remove(FIRST_HEADER);
+        final HttpHeaders defaultHttpHeadersResult = defaultHttpHeaders.remove(FIRST_HEADER);
+
+        assertThat(headers.contains(FIRST_HEADER)).isFalse();
+        assertThat(defaultHttpHeadersResult.contains(FIRST_HEADER)).isFalse();
+    }
+
+    @Test
+    public void shouldPutAll() {
+        final List<String> putAllHeaders = List.of("test-value1", "test-value2");
+        final Map<String, List<String>> mapToAdd = Map.of("Put-All-Header", putAllHeaders, FIRST_HEADER, List.of("new-value"));
+
+        cut.putAll(mapToAdd);
+        defaultHttpHeaders.putAll(mapToAdd);
+
+        assertThat(cut.getAll("Put-All-Header")).hasSize(2).containsExactlyElementsOf(putAllHeaders);
+        assertThat(defaultHttpHeaders.getAll("Put-All-Header")).hasSize(2).containsExactlyElementsOf(putAllHeaders);
+
+        // Existing headers in the map should be overridden by this operation
+        assertThat(cut.getAll(FIRST_HEADER)).hasSize(1).containsExactly("new-value");
+        assertThat(defaultHttpHeaders.getAll(FIRST_HEADER)).hasSize(1).containsExactly("new-value");
+    }
+
+    @Test
+    public void shouldGetKeySet() {
+        assertThat(cut.keySet()).hasSize(2).containsExactly(FIRST_HEADER, SECOND_HEADER);
+        assertThat(defaultHttpHeaders.keySet()).hasSize(2).containsExactly(FIRST_HEADER, SECOND_HEADER);
+    }
+
+    @Test
+    public void shouldGetValues() {
+        assertThat(cut.values())
+            .hasSize(2)
+            .containsExactly(List.of(FIRST_HEADER_VALUE_1, FIRST_HEADER_VALUE_2), List.of(SECOND_HEADER_VALUE));
+
+        assertThat(defaultHttpHeaders.values())
+            .hasSize(2)
+            .containsExactly(List.of(FIRST_HEADER_VALUE_1, FIRST_HEADER_VALUE_2), List.of(SECOND_HEADER_VALUE));
+    }
+
+    @Test
+    public void shouldGetEntrySet() {
+        assertThat(cut.entrySet())
+            .hasSize(2)
+            .containsExactly(
+                Map.entry(FIRST_HEADER, List.of(FIRST_HEADER_VALUE_1, FIRST_HEADER_VALUE_2)),
+                Map.entry(SECOND_HEADER, List.of(SECOND_HEADER_VALUE))
+            );
+
+        assertThat(defaultHttpHeaders.entrySet())
+            .hasSize(2)
+            .containsExactly(
+                Map.entry(FIRST_HEADER, List.of(FIRST_HEADER_VALUE_1, FIRST_HEADER_VALUE_2)),
+                Map.entry(SECOND_HEADER, List.of(SECOND_HEADER_VALUE))
+            );
+    }
+
+    @Test
+    public void shouldGetFirst() {
+        assertThat(cut.getFirst(FIRST_HEADER)).isEqualTo(FIRST_HEADER_VALUE_1);
+        assertThat(defaultHttpHeaders.getFirst(FIRST_HEADER)).isEqualTo(FIRST_HEADER_VALUE_1);
+    }
+
+    @Test
+    public void shouldNotGetFirst() {
+        assertThat(cut.getFirst("Content-Type")).isNull();
+        assertThat(defaultHttpHeaders.getFirst("Content-Type")).isNull();
+    }
+
+    @Test
+    public void shouldAddValue() {
+        cut.add(FIRST_HEADER, "new-value");
+        defaultHttpHeaders.add(FIRST_HEADER, "new-value");
+
+        assertThat(cut.getAll(FIRST_HEADER)).hasSize(3).containsExactly(FIRST_HEADER_VALUE_1, FIRST_HEADER_VALUE_2, "new-value");
+        assertThat(defaultHttpHeaders.getAll(FIRST_HEADER))
+            .hasSize(3)
+            .containsExactly(FIRST_HEADER_VALUE_1, FIRST_HEADER_VALUE_2, "new-value");
+    }
+
+    @Test
+    public void shouldAddValueNonExistingKey() {
+        cut.add("New-Header", "new-value");
+        defaultHttpHeaders.add("New-Header", "new-value");
+
+        assertThat(cut.getAll("New-Header")).hasSize(1).containsExactly("new-value");
+        assertThat(defaultHttpHeaders.getAll("New-Header")).hasSize(1).containsExactly("new-value");
+    }
+
+    @Test
+    public void shouldSetValue() {
+        cut.set(FIRST_HEADER, "new-value");
+        cut.set("New-Header", "new-value");
+        defaultHttpHeaders.set(FIRST_HEADER, "new-value");
+        defaultHttpHeaders.set("New-Header", "new-value");
+
+        assertThat(cut.getAll(FIRST_HEADER)).hasSize(1).containsExactly("new-value");
+        assertThat(defaultHttpHeaders.getAll(FIRST_HEADER)).hasSize(1).containsExactly("new-value");
+
+        assertThat(cut.getAll("New-Header")).hasSize(1).containsExactly("new-value");
+        assertThat(defaultHttpHeaders.getAll("New-Header")).hasSize(1).containsExactly("new-value");
+    }
+
+    @Test
+    public void shouldSetAll() {
+        final Map<String, String> mapToAdd = Map.of("Put-All-Header", "test-value1", FIRST_HEADER, "new-value");
+
+        cut.setAll(mapToAdd);
+        defaultHttpHeaders.setAll(mapToAdd);
+
+        assertThat(cut.getAll("Put-All-Header")).hasSize(1).containsExactly("test-value1");
+        assertThat(defaultHttpHeaders.getAll("Put-All-Header")).hasSize(1).containsExactly("test-value1");
+
+        // Existing headers in the map should be overridden by this operation
+        assertThat(cut.getAll(FIRST_HEADER)).hasSize(1).containsExactly("new-value");
+        assertThat(defaultHttpHeaders.getAll(FIRST_HEADER)).hasSize(1).containsExactly("new-value");
+    }
+}


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/7930

**Description**

Add Map capabilities in VertxHttpHeaders implementation as it's used by `gravitee-reporter-elasticsearch` as a map in freemarker template.
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `1.1.9-issues-7930-fix-es-headers-reporting-3-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/connector/gravitee-connector-http/1.1.9-issues-7930-fix-es-headers-reporting-3-SNAPSHOT/gravitee-connector-http-1.1.9-issues-7930-fix-es-headers-reporting-3-SNAPSHOT.zip)
  <!-- Version placeholder end -->
