### PR TITLE
Return null instead of empty list when getting an undefined header

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@
 
     <properties>
         <gravitee-bom.version>1.4</gravitee-bom.version>
-        <gravitee-connector-api.version>1.1.2</gravitee-connector-api.version>
+        <gravitee-connector-api.version>1.1.3</gravitee-connector-api.version>
         <!-- Property used by the publication job in CI-->
         <publish-folder-path>graviteeio-apim/plugins/connectors</publish-folder-path>
     </properties>

--- a/src/main/java/io/gravitee/connector/http/vertx/VertxHttpHeaders.java
+++ b/src/main/java/io/gravitee/connector/http/vertx/VertxHttpHeaders.java
@@ -138,7 +138,8 @@ public class VertxHttpHeaders implements HttpHeaders, MultiValueMap<String, Stri
      */
     @Override
     public List<String> get(Object key) {
-        return headers.getAll(String.valueOf(key));
+        String keyAsString = String.valueOf(key);
+        return contains(keyAsString) ? getAll(keyAsString) : null;
     }
 
     /**

--- a/src/test/java/io/gravitee/connector/http/vertx/VertxHttpHeadersTest.java
+++ b/src/test/java/io/gravitee/connector/http/vertx/VertxHttpHeadersTest.java
@@ -119,8 +119,8 @@ public class VertxHttpHeadersTest {
     @Test
     public void shouldGet() {
         Object key = new Object();
-        assertThat(cut.get(key)).isEmpty();
-        assertThat(defaultHttpHeaders.get(key)).isEmpty();
+        assertThat(cut.get(key)).isNull();
+        assertThat(defaultHttpHeaders.get(key)).isNull();
 
         key = FIRST_HEADER;
         assertThat(cut.get(key)).hasSize(2);
@@ -131,8 +131,8 @@ public class VertxHttpHeadersTest {
         assertThat(defaultHttpHeaders.get(key)).hasSize(1);
 
         key = ACCEPT_LANGUAGE;
-        assertThat(cut.get(key)).isEmpty();
-        assertThat(defaultHttpHeaders.get(key)).isEmpty();
+        assertThat(cut.get(key)).isNull();
+        assertThat(defaultHttpHeaders.get(key)).isNull();
     }
 
     @Test


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/7812
https://github.com/gravitee-io/issues/issues/8153

Matching implementation done in https://github.com/gravitee-io/gravitee-gateway-api/pull/125

**Description**

Return null instead of an empty list when getting an undefined header.
Returning an empty list is causing the following EL to be evaluated to `true`:
`{#request.headers['X-Gravitee-No-Present'] != null}`
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `1.1.10-7812-bump-connector-api-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/connector/gravitee-connector-http/1.1.10-7812-bump-connector-api-SNAPSHOT/gravitee-connector-http-1.1.10-7812-bump-connector-api-SNAPSHOT.zip)
  <!-- Version placeholder end -->
