### PR TITLE
Fix WebSocket connection

### DIFF
--- a/src/main/java/io/gravitee/connector/http/AbstractHttpConnector.java
+++ b/src/main/java/io/gravitee/connector/http/AbstractHttpConnector.java
@@ -107,11 +107,8 @@ public abstract class AbstractHttpConnector<E extends HttpEndpoint> extends Abst
         try {
             final URL url = new URL(null, uri, URL_HANDLER);
 
-            final String protocol = url.getProtocol();
-
-            final int port = url.getPort() != -1
-                ? url.getPort()
-                : protocol.charAt(protocol.length() - 1) == 's' ? SECURE_PORT : UNSECURE_PORT;
+            final int defaultPort = isSecureProtocol(url.getProtocol()) ? SECURE_PORT : UNSECURE_PORT;
+            final int port = url.getPort() != -1 ? url.getPort() : defaultPort;
 
             final String host = (port == UNSECURE_PORT || port == SECURE_PORT) ? url.getHost() : url.getHost() + ':' + port;
 
@@ -223,9 +220,7 @@ public abstract class AbstractHttpConnector<E extends HttpEndpoint> extends Abst
 
         HttpClientSslOptions sslOptions = endpoint.getHttpClientSslOptions();
 
-        final String protocol = target.getProtocol();
-
-        if (protocol.charAt(protocol.length() - 1) == 's') {
+        if (isSecureProtocol(target.getProtocol())) {
             // Configure SSL
             options.setSsl(true).setUseAlpn(true);
 
@@ -364,6 +359,18 @@ public abstract class AbstractHttpConnector<E extends HttpEndpoint> extends Abst
 
     private Function<Thread, HttpClient> createHttpClient() {
         return thread -> Vertx.currentContext().owner().createHttpClient(options);
+    }
+
+    /**
+     * Check if input protocol is secure or not based on its last character ('s' for secure).
+     * Also, to be considered as secure the length of protocol's name the must be at least 2 characters to avoid considering `ws` as secure.
+     * ⚠️ This method is implemented using `charAt` and `length` methods for performance reasons. Be very careful when changing this method.
+     *
+     * @param protocol the protocol to check
+     * @return true if protocol is secure, false otherwise
+     */
+    protected static boolean isSecureProtocol(String protocol) {
+        return protocol.charAt(protocol.length() - 1) == 's' && protocol.length() > 2;
     }
 
     private void printHttpClientConfiguration() {

--- a/src/main/java/io/gravitee/connector/http/ws/WebSocketConnection.java
+++ b/src/main/java/io/gravitee/connector/http/ws/WebSocketConnection.java
@@ -71,6 +71,11 @@ public class WebSocketConnection extends AbstractHttpConnection<HttpEndpoint> {
 
         WebSocketConnectOptions options = new WebSocketConnectOptions().setHost(host).setPort(port).setURI(uri);
 
+        // Add subprotocols based on the ones specified in the request headers
+        if (wsProxyRequest.headers().contains(HttpHeaderNames.SEC_WEBSOCKET_PROTOCOL)) {
+            wsProxyRequest.headers().getAll(HttpHeaderNames.SEC_WEBSOCKET_PROTOCOL).forEach(options::addSubProtocol);
+        }
+
         wsProxyRequest.headers().forEach(entry -> options.addHeader(entry.getKey(), entry.getValue()));
 
         httpClient.webSocket(

--- a/src/test/java/io/gravitee/connector/http/AbstractHttpConnectorTest.java
+++ b/src/test/java/io/gravitee/connector/http/AbstractHttpConnectorTest.java
@@ -1,0 +1,62 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.connector.http;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+import io.gravitee.connector.http.endpoint.HttpEndpoint;
+import io.gravitee.gateway.api.proxy.ProxyRequest;
+import io.gravitee.node.api.configuration.Configuration;
+import io.vertx.core.http.HttpClientOptions;
+import org.junit.Test;
+
+class TestHttpConnector extends AbstractHttpConnector<HttpEndpoint> {
+
+    public TestHttpConnector(HttpEndpoint endpoint, Configuration configuration) {
+        super(endpoint, configuration);
+    }
+
+    @Override
+    protected AbstractHttpConnection<HttpEndpoint> create(ProxyRequest request) {
+        return null;
+    }
+}
+
+public class AbstractHttpConnectorTest {
+
+    @Test
+    public void createHttpClientOptions_DoesntEnableSSLForWsProtocol() throws Exception {
+        HttpEndpoint endpoint = new HttpEndpoint(null, "Endpoint", "ws://localhost:8080/api");
+
+        AbstractHttpConnector<HttpEndpoint> connector = new TestHttpConnector(endpoint, mock(Configuration.class));
+        HttpClientOptions result = connector.createHttpClientOptions();
+
+        assertThat(result.isSsl()).isFalse();
+    }
+
+    @Test
+    public void isSecureProtocol_ReturnTrueForHttpsAndWss() {
+        assertThat(TestHttpConnector.isSecureProtocol("https")).isTrue();
+        assertThat(TestHttpConnector.isSecureProtocol("wss")).isTrue();
+    }
+
+    @Test
+    public void isSecureProtocol_ReturnFalseForHttpAndWs() {
+        assertThat(TestHttpConnector.isSecureProtocol("http")).isFalse();
+        assertThat(TestHttpConnector.isSecureProtocol("ws")).isFalse();
+    }
+}


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/8228
https://github.com/gravitee-io/issues/issues/8324

**Description**

- Do not consider `ws` as a secure protocol
- Set WS subprotocols based on the `sec-websocket-protocol` header
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `1.1.11-fix-websocket-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/connector/gravitee-connector-http/1.1.11-fix-websocket-SNAPSHOT/gravitee-connector-http-1.1.11-fix-websocket-SNAPSHOT.zip)
  <!-- Version placeholder end -->
