### PR TITLE
fix: make ws proxy response connected

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
 
     <groupId>io.gravitee.connector</groupId>
     <artifactId>gravitee-connector-http</artifactId>
-    <version>2.0.5</version>
+    <version>2.0.6-8253-websocket-entrypoint-SNAPSHOT</version>
 
     <name>Gravitee.io - Connector - HTTP</name>
 

--- a/src/main/java/io/gravitee/connector/http/ws/SwitchProtocolProxyResponse.java
+++ b/src/main/java/io/gravitee/connector/http/ws/SwitchProtocolProxyResponse.java
@@ -71,6 +71,6 @@ public class SwitchProtocolProxyResponse implements Response {
 
     @Override
     public boolean connected() {
-        return false;
+        return true;
     }
 }


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/8253

**Description**

Jupiter engine with V3 compatibility relies on `ProxyResponse.connected()` to propagate the proxy response to the reactive chain. Since we have introduced an adapter in Jupiter to support websocket in v3 compatibility mode, we need the `connected()` method indicates `true` after the websocket connection occurred with the backend and the backend response indicates to upgrade to websocket (ie: switch protocol).