### PR TITLE
fix: use native buffer to avoid byte array copy

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
 
     <groupId>io.gravitee.connector</groupId>
     <artifactId>gravitee-connector-http</artifactId>
-    <version>2.0.6</version>
+    <version>2.0.7-apim-137-jupiter-backpressure-on-post-SNAPSHOT</version>
 
     <name>Gravitee.io - Connector - HTTP</name>
 
@@ -37,6 +37,7 @@
         <gravitee-bom.version>1.4</gravitee-bom.version>
         <gravitee-common.version>1.26.1</gravitee-common.version>
         <gravitee-connector-api.version>1.1.3</gravitee-connector-api.version>
+        <gravitee-gateway-api.version>1.47.0</gravitee-gateway-api.version>
         <!-- Property used by the publication job in CI-->
         <publish-folder-path>graviteeio-apim/plugins/connectors</publish-folder-path>
     </properties>
@@ -50,6 +51,11 @@
                 <version>${gravitee-bom.version}</version>
                 <scope>import</scope>
                 <type>pom</type>
+            </dependency>
+            <dependency>
+                <groupId>io.gravitee.gateway</groupId>
+                <artifactId>gravitee-gateway-api</artifactId>
+                <version>${gravitee-gateway-api.version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/src/main/java/io/gravitee/connector/http/HttpConnection.java
+++ b/src/main/java/io/gravitee/connector/http/HttpConnection.java
@@ -184,7 +184,7 @@ public class HttpConnection<T extends HttpResponse> extends AbstractHttpConnecti
             response.cancelHandler(tracker);
 
             // Copy body content
-            clientResponse.handler(event -> response.bodyHandler().handle(Buffer.buffer(event.getBytes())));
+            clientResponse.handler(event -> response.bodyHandler().handle(Buffer.buffer(event)));
 
             // Signal end of the response
             clientResponse.endHandler(event -> {
@@ -205,7 +205,7 @@ public class HttpConnection<T extends HttpResponse> extends AbstractHttpConnecti
             });
 
             clientResponse.customFrameHandler(frame ->
-                response.writeCustomFrame(HttpFrame.create(frame.type(), frame.flags(), Buffer.buffer(frame.payload().getBytes())))
+                response.writeCustomFrame(HttpFrame.create(frame.type(), frame.flags(), Buffer.buffer(frame.payload())))
             );
 
             // And send it to the client
@@ -266,7 +266,7 @@ public class HttpConnection<T extends HttpResponse> extends AbstractHttpConnecti
             this.writeHeaders();
         }
 
-        httpClientRequest.write(io.vertx.core.buffer.Buffer.buffer(chunk.getBytes()));
+        httpClientRequest.write(io.vertx.core.buffer.Buffer.buffer(chunk.getNativeBuffer()));
 
         return this;
     }
@@ -327,7 +327,11 @@ public class HttpConnection<T extends HttpResponse> extends AbstractHttpConnecti
 
     @Override
     public Connection writeCustomFrame(HttpFrame frame) {
-        httpClientRequest.writeCustomFrame(frame.type(), frame.flags(), io.vertx.core.buffer.Buffer.buffer(frame.payload().getBytes()));
+        httpClientRequest.writeCustomFrame(
+            frame.type(),
+            frame.flags(),
+            io.vertx.core.buffer.Buffer.buffer(frame.payload().getNativeBuffer())
+        );
 
         return this;
     }

--- a/src/main/java/io/gravitee/connector/http/ws/WebSocketConnection.java
+++ b/src/main/java/io/gravitee/connector/http/ws/WebSocketConnection.java
@@ -94,7 +94,7 @@ public class WebSocketConnection extends AbstractHttpConnection<HttpEndpoint> {
                                         .result()
                                         .writeFrame(
                                             io.vertx.core.http.WebSocketFrame.binaryFrame(
-                                                io.vertx.core.buffer.Buffer.buffer(frame.data().getBytes()),
+                                                io.vertx.core.buffer.Buffer.buffer(frame.data().getNativeBuffer()),
                                                 frame.isFinal()
                                             )
                                         );

--- a/src/main/java/io/gravitee/connector/http/ws/WebSocketFrame.java
+++ b/src/main/java/io/gravitee/connector/http/ws/WebSocketFrame.java
@@ -45,7 +45,7 @@ public class WebSocketFrame implements io.gravitee.gateway.api.ws.WebSocketFrame
 
     @Override
     public Buffer data() {
-        return Buffer.buffer(frame.binaryData().getBytes());
+        return Buffer.buffer(frame.binaryData());
     }
 
     @Override


### PR DESCRIPTION
**Issue**

https://graviteecommunity.atlassian.net/browse/APIM-137

**Description**

Just an improvement to avoid copying byte arrays and memory pressure.
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `2.0.7-apim-137-jupiter-backpressure-on-post-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/connector/gravitee-connector-http/2.0.7-apim-137-jupiter-backpressure-on-post-SNAPSHOT/gravitee-connector-http-2.0.7-apim-137-jupiter-backpressure-on-post-SNAPSHOT.zip)
  <!-- Version placeholder end -->
