### PR TITLE
fix: allow to optionally propagate accept-encoding

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
 
     <groupId>io.gravitee.connector</groupId>
     <artifactId>gravitee-connector-http</artifactId>
-    <version>1.1.11</version>
+    <version>1.1.12-7935-optionnally-propagate-accept-encoding-SNAPSHOT</version>
 
     <name>Gravitee.io - Connector - HTTP</name>
 

--- a/src/main/java/io/gravitee/connector/http/HttpConnection.java
+++ b/src/main/java/io/gravitee/connector/http/HttpConnection.java
@@ -90,8 +90,10 @@ public class HttpConnection<T extends HttpResponse> extends AbstractHttpConnecti
             request.headers().remove(header.toString());
         }
 
-        // Let the API Owner choose the Accept-Encoding between the gateway and the backend
-        request.headers().remove(io.gravitee.common.http.HttpHeaders.ACCEPT_ENCODING);
+        if (!endpoint.getHttpClientOptions().isPropagateClientAcceptEncoding()) {
+            // Let the API Owner choose the Accept-Encoding between the gateway and the backend
+            request.headers().remove(io.gravitee.common.http.HttpHeaders.ACCEPT_ENCODING);
+        }
 
         Future<HttpClientRequest> request = prepareUpstreamRequest(httpClient, port, host, uri);
         request.onComplete(

--- a/src/main/java/io/gravitee/connector/http/endpoint/HttpClientOptions.java
+++ b/src/main/java/io/gravitee/connector/http/endpoint/HttpClientOptions.java
@@ -30,6 +30,7 @@ public class HttpClientOptions implements Serializable {
     public static boolean DEFAULT_KEEP_ALIVE = true;
     public static boolean DEFAULT_PIPELINING = false;
     public static boolean DEFAULT_USE_COMPRESSION = true;
+    public static boolean DEFAULT_PROPAGATE_CLIENT_ACCEPT_ENCODING = false;
     public static boolean DEFAULT_FOLLOW_REDIRECTS = false;
     public static boolean DEFAULT_CLEAR_TEXT_UPGRADE = true;
     public static ProtocolVersion DEFAULT_PROTOCOL_VERSION = ProtocolVersion.HTTP_1_1;
@@ -47,6 +48,8 @@ public class HttpClientOptions implements Serializable {
     private int maxConcurrentConnections = DEFAULT_MAX_CONCURRENT_CONNECTIONS;
 
     private boolean useCompression = DEFAULT_USE_COMPRESSION;
+
+    private boolean propagateClientAcceptEncoding = DEFAULT_PROPAGATE_CLIENT_ACCEPT_ENCODING;
 
     private boolean followRedirects = DEFAULT_FOLLOW_REDIRECTS;
 
@@ -132,5 +135,14 @@ public class HttpClientOptions implements Serializable {
 
     public void setVersion(ProtocolVersion version) {
         this.version = version;
+    }
+
+    public boolean isPropagateClientAcceptEncoding() {
+        // Propagate Accept-Encoding can only be made if useCompression is disabled.
+        return !useCompression && propagateClientAcceptEncoding;
+    }
+
+    public void setPropagateClientAcceptEncoding(boolean propagateClientAcceptEncoding) {
+        this.propagateClientAcceptEncoding = propagateClientAcceptEncoding;
     }
 }

--- a/src/main/resources/schemas/schema-form.json
+++ b/src/main/resources/schemas/schema-form.json
@@ -7,6 +7,21 @@
       "title": "HTTP Options",
       "id": "urn:jsonschema:io:gravitee:connector:http:configuration:HttpOptions",
       "properties": {
+        "clearTextUpgrade": {
+          "title": "Allow h2c Clear Text Upgrade",
+          "description": "If enabled, an h2c connection is established using an HTTP/1.1 Upgrade request. If disabled, h2c connection is established directly (with prior knowledge) ",
+          "type": "boolean",
+          "default": true,
+          "x-schema-form": {
+            "hidden": [
+              {
+                "$eq": {
+                  "http.version": "HTTP_1_1"
+                }
+              }
+            ]
+          }
+        },
         "version": {
           "title": "HTTP Protocol version",
           "description": "The version of the HTTP protocol to use",
@@ -47,7 +62,7 @@
         },
         "useCompression": {
           "title": "Enable compression (gzip, deflate)",
-          "description": "The gateway can let the remote http server know that it supports compression, and will be able to handle compressed response bodies.",
+          "description": "The gateway can let the remote http server know that it supports compression. In case the remote http server returns a compressed response, the gateway will decompress it. Leave that option off if you don't want compression between the gateway and the remote server.",
           "type": "boolean",
           "default": true
         },
@@ -69,16 +84,16 @@
           "description": "Maximum pool size for connections.",
           "default": 100
         },
-        "clearTextUpgrade": {
-          "title": "Allow h2c Clear Text Upgrade",
-          "description": "If enabled, an h2c connection is established using an HTTP/1.1 Upgrade request. If disabled, h2c connection is established directly (with prior knowledge) ",
+        "propagateClientAcceptEncoding": {
+          "title": "Propagate client Accept-Encoding header (no decompression if any)",
+          "description": "The gateway will propagate the Accept-Encoding header's value specified by the client's request to the backend (if any). The gateway will <b>NEVER attempt to decompress the content</b> if the backend response is compressed (gzip, deflate). It is then not possible to apply transformation policy if the body is compressed. Also, body will appear compressed if logging is enabled for the API. <b>DO NOT</b> activate this option if you plan to play with body responses.",
           "type": "boolean",
-          "default": true,
+          "default": false,
           "x-schema-form": {
             "hidden": [
               {
                 "$eq": {
-                  "http.version": "HTTP_1_1"
+                  "http.useCompression": true
                 }
               }
             ]
@@ -90,7 +105,7 @@
     "headers": {
       "type": "array",
       "title": "HTTP Headers",
-      "description": "Default HTTP headers added or overrided by the API gateway to upstream",
+      "description": "Default HTTP headers added or overridden by the API gateway to upstream",
       "items": {
         "type": "object",
         "title": "Header",


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/7935

**Description**

This allow to get back to the previous behavior mentioned in the issue while keeping the benefit of the fix related to unsupported encoded content.

Here is a summary of the different cases that could occur depending on what has been configured.

| **Case** | **Client request**<br>**Accept-Encoding** | **Server compression enabled** | **Endpoint compression enabled** | **Endpoint propagate client Accept-Encoding header** | **Backend response encoding** | **Client response encoding** |
| --- | --- | --- | --- | --- | --- | --- |
| **1** | _none_ | _no matter_ | false | false | none | **none** |
| **2** | _none_ | _no matter_ | true | false | gzip, deflate | **none** |
| **3** | gzip, deflate | _no matter_ | false | true | gzip, deflate | **gzip, deflate** |
| **4** | gzip, deflate | true | true | false | gzip, deflate | **gzip, deflate** |

1. The client didn&#39;t ask for compressed content. The gateway always return a plain content.
1. The client didn&#39;t ask for compressed content. The gateway always return a plain content event if compressed content is returned by the backend. Gateway will uncompress it because the option is enabled (endpoint compression enabled).
1. Client asked for `gzip, deflate` and it has been propagated to the backend (propagate client accept-encoding). The backend response is compressed and gateway support for compression is disabled. The gateway does not decompress the content and returns it as it is.
1. Client asked for `gzip, deflate`. Backend returns compressed content because gateway ask for it (and uncompress it). Gateway will recompress the content because it has been asked by the client and the option it enable (server compression enabled).
