### PR TITLE
Add unit tests for HttpConnectorFactory class

### DIFF
--- a/src/main/java/io/gravitee/connector/http/HttpConnectorFactory.java
+++ b/src/main/java/io/gravitee/connector/http/HttpConnectorFactory.java
@@ -78,7 +78,7 @@ public class HttpConnectorFactory implements ConnectorFactory<Connector<Connecti
 
     private String convert(String value) {
         if (value != null && !value.isEmpty()) {
-            return templateEngine.convert(value);
+            return templateEngine.getValue(value, String.class);
         }
 
         return value;

--- a/src/test/java/io/gravitee/connector/http/HttpConnectorFactoryTest.java
+++ b/src/test/java/io/gravitee/connector/http/HttpConnectorFactoryTest.java
@@ -1,0 +1,121 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.connector.http;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.gravitee.common.http.HttpHeader;
+import io.gravitee.connector.api.Connection;
+import io.gravitee.connector.api.Connector;
+import io.gravitee.connector.api.ConnectorBuilder;
+import io.gravitee.connector.api.ConnectorContext;
+import io.gravitee.connector.http.grpc.GrpcConnector;
+import io.gravitee.gateway.api.proxy.ProxyRequest;
+import java.util.Map;
+import org.junit.Before;
+import org.junit.Test;
+
+public class HttpConnectorFactoryTest {
+
+    ObjectMapper mapper = new ObjectMapper();
+
+    HttpConnectorFactory factory = new HttpConnectorFactory();
+
+    ConnectorBuilder connectorBuilder;
+
+    @Before
+    public void setUp() {
+        connectorBuilder = mock(ConnectorBuilder.class);
+        when(connectorBuilder.getMapper()).thenReturn(mapper);
+    }
+
+    @Test
+    public void shouldReturnCorrectSupportedTypes() {
+        assertThat(factory.supportedTypes()).containsExactly("http", "grpc");
+    }
+
+    @Test
+    public void shouldCreateAnHttpConnector() {
+        String target = "http://localhost:8080";
+        String configuration = "{\"type\":\"http\", \"target\":\"" + target + "\", \"name\":\"test\"}";
+
+        Connector<Connection, ProxyRequest> connector = factory.create(target, configuration, connectorBuilder);
+        assertThat(connector).isInstanceOf(HttpConnector.class);
+        assertThat(((HttpConnector) connector).endpoint.target()).isEqualTo(target);
+    }
+
+    @Test
+    public void shouldCreateAGrpcConnector() {
+        String target = "http://localhost:8080";
+        String configuration = "{\"type\":\"grpc\", \"target\":\"" + target + "\", \"name\":\"test\"}";
+
+        assertThat(factory.create(target, configuration, connectorBuilder)).isInstanceOf(GrpcConnector.class);
+    }
+
+    @Test
+    public void shouldCreateAConnectorWithSpELEndpoint() {
+        String target = "http://localhost:8080";
+        String configuration = "{\"type\":\"http\", \"target\":\"{#properties['backend']}\", \"name\":\"test\"}";
+
+        ConnectorContext context = new ConnectorContext();
+        context.setProperties(Map.of("backend", "http://localhost:8080"));
+        when(connectorBuilder.getContext()).thenReturn(context);
+
+        Connector<Connection, ProxyRequest> connector = factory.create(target, configuration, connectorBuilder);
+        assertThat(connector).isInstanceOf(HttpConnector.class);
+        assertThat(((HttpConnector) connector).endpoint.target()).isEqualTo(target);
+    }
+
+    @Test
+    public void shouldCreateAConnectorWithHttpProxyConfig() {
+        String target = "http://localhost:8080";
+        String configuration =
+            "{\"type\":\"http\", \"target\":\"" +
+            target +
+            "\", \"name\":\"test\", \"proxy\":{\"host\":\"localhost\", \"username\":\"user\", \"password\":\"pwd\"}}";
+
+        ConnectorContext context = new ConnectorContext();
+        context.setProperties(Map.of("backend", "http://localhost:8080"));
+        when(connectorBuilder.getContext()).thenReturn(context);
+
+        Connector<Connection, ProxyRequest> connector = factory.create(target, configuration, connectorBuilder);
+        assertThat(connector).isInstanceOf(HttpConnector.class);
+        assertThat(((HttpConnector) connector).endpoint.getHttpProxy())
+            .extracting("host", "username", "password")
+            .containsExactly("localhost", "user", "pwd");
+    }
+
+    @Test
+    public void shouldCreateAConnectorWithDefaultHttpHeaderConfig() {
+        String target = "http://localhost:8080";
+        String configuration =
+            "{\"type\":\"http\", \"target\":\"" +
+            target +
+            "\", \"name\":\"test\", \"headers\":[{\"name\":\"X-Gravitee-Api\",\"value\":\"test\"}, {\"name\":\"Empty-Header\",\"value\":\"\"}]}";
+
+        ConnectorContext context = new ConnectorContext();
+        context.setProperties(Map.of("backend", "http://localhost:8080"));
+        when(connectorBuilder.getContext()).thenReturn(context);
+
+        Connector<Connection, ProxyRequest> connector = factory.create(target, configuration, connectorBuilder);
+        assertThat(connector).isInstanceOf(HttpConnector.class);
+        assertThat(((HttpConnector) connector).endpoint.getHeaders())
+            .containsExactly(new HttpHeader("X-Gravitee-Api", "test"), new HttpHeader("Empty-Header", ""));
+    }
+}


### PR DESCRIPTION
**Issue**

NA

**Description**

Add unit tests for HttpConnectorFactory class to cover the current behavior regarding endpoint and Expression Language
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `1.1.12`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/connector/gravitee-connector-http/1.1.12/gravitee-connector-http-1.1.12.zip)
  <!-- Version placeholder end -->
