### PR TITLE
Do not use RxJava stuff for now as it will create a breaking change

### DIFF
--- a/src/main/java/io/gravitee/connector/http/HttpConnectorFactory.java
+++ b/src/main/java/io/gravitee/connector/http/HttpConnectorFactory.java
@@ -78,7 +78,7 @@ public class HttpConnectorFactory implements ConnectorFactory<Connector<Connecti
 
     private String convert(String value) {
         if (value != null && !value.isEmpty()) {
-            return templateEngine.eval(value, String.class).blockingGet();
+            return templateEngine.getValue(value, String.class);
         }
 
         return value;


### PR DESCRIPTION
**Issue**

NA

**Description**

Do not use RxJava stuff for now as it will create a breaking change
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `2.0.9-remove-rxjava-stuff-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/connector/gravitee-connector-http/2.0.9-remove-rxjava-stuff-SNAPSHOT/gravitee-connector-http-2.0.9-remove-rxjava-stuff-SNAPSHOT.zip)
  <!-- Version placeholder end -->
