### PR TITLE
Update validation spec in API proxy config schema form

### DIFF
--- a/src/main/resources/schemas/schema-form.json
+++ b/src/main/resources/schemas/schema-form.json
@@ -269,7 +269,7 @@
           "properties": { "enabled": { "const": false } }
         },
         {
-          "properties": { "useSystemProxy": { "const": true } }
+          "properties": { "enabled": { "const": true }, "useSystemProxy": { "const": true } }
         },
         {
           "properties": { "enabled": { "const": true }, "useSystemProxy": { "const": false } },


### PR DESCRIPTION
## Issue

https://github.com/gravitee-io/issues/issues/8698
https://gravitee.atlassian.net/browse/APIM-415

## Description

To validate against oneOf, the given data must be valid against exactly one of the given subschemas.
See https://json-schema.org/understanding-json-schema/reference/combining.html#oneof
It's like a XOR, if it's valid against multiple subschemas then it's reported invalid. 
This was the case when proxy was disabled but system proxy enabled. 
So I strengthen the subschemas related to system proxy.
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `2.1.1-8698-fix-proxy-settings-validation-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/connector/gravitee-connector-http/2.1.1-8698-fix-proxy-settings-validation-SNAPSHOT/gravitee-connector-http-2.1.1-8698-fix-proxy-settings-validation-SNAPSHOT.zip)
  <!-- Version placeholder end -->
