### PR TITLE
fix: avoid chunk corruption with tls and http1.1

### DIFF
--- a/src/main/java/io/gravitee/connector/http/HttpConnection.java
+++ b/src/main/java/io/gravitee/connector/http/HttpConnection.java
@@ -198,7 +198,7 @@ public class HttpConnection<T extends HttpResponse> extends AbstractHttpConnecti
             response.cancelHandler(tracker);
 
             // Copy body content
-            clientResponse.handler(event -> response.bodyHandler().handle(Buffer.buffer(event)));
+            clientResponse.handler(event -> response.bodyHandler().handle(Buffer.buffer(event.getBytes())));
 
             // Signal end of the response
             clientResponse.endHandler(event -> {


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/8956
https://gravitee.atlassian.net/browse/APIM-1149

**Description**

Revert back to copy byte array instead of relying on underlying `ByteBuf` because it can produce corrupted chunks when activating TLS and requesting in http1.1 (see https://github.com/eclipse-vertx/vert.x/issues/4509)

The optimization can be reintroduced in a later v2.2.0 to be used by APIM 3.21.x since vertx has been upgraded to 4.3.8 which contains a fix.
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `2.1.2-apim-1126-fix-tls-chunk-issue-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/connector/gravitee-connector-http/2.1.2-apim-1126-fix-tls-chunk-issue-SNAPSHOT/gravitee-connector-http-2.1.2-apim-1126-fix-tls-chunk-issue-SNAPSHOT.zip)
  <!-- Version placeholder end -->
