### PR TITLE
Reapply ByteBuf optimization and bump dependencies

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -1,13 +1,12 @@
 = HTTP Connector
 
 ifdef::env-github[]
-image:https://img.shields.io/static/v1?label=Available%20at&message=Gravitee.io&color=1EC9D2["Gravitee.io", link="https://download.gravitee.io/#graviteeio-apim/plugins/connectors/gravitee-connector-http/"]
-image:https://img.shields.io/badge/License-Apache%202.0-blue.svg["License", link="https://github.com/gravitee-io/gravitee-connector-http/blob/master/LICENSE.txt"]
-image:https://img.shields.io/badge/semantic--release-conventional%20commits-e10079?logo=semantic-release["Releases", link="https://github.com/gravitee-io/gravitee-connector-http/releases"]
-image:https://circleci.com/gh/gravitee-io/gravitee-connector-http.svg?style=svg["CircleCI", link="https://circleci.com/gh/gravitee-io/gravitee-connector-http"]
-image:https://f.hubspotusercontent40.net/hubfs/7600448/gravitee-github-button.jpg["Join the community forum", link="https://community.gravitee.io?utm_source=readme", height=20]
+image:https://img.shields.io/static/v1?label=Available%20at&message=Gravitee.io&color=1EC9D2["Gravitee.io",link="https://download.gravitee.io/#graviteeio-apim/plugins/connectors/gravitee-connector-http/"]
+image:https://img.shields.io/badge/License-Apache%202.0-blue.svg["License",link="https://github.com/gravitee-io/gravitee-connector-http/blob/master/LICENSE.txt"]
+image:https://img.shields.io/badge/semantic--release-conventional%20commits-e10079?logo=semantic-release["Releases",link="https://github.com/gravitee-io/gravitee-connector-http/releases"]
+image:https://circleci.com/gh/gravitee-io/gravitee-connector-http.svg?style=svg["CircleCI",link="https://circleci.com/gh/gravitee-io/gravitee-connector-http"]
+image:https://f.hubspotusercontent40.net/hubfs/7600448/gravitee-github-button.jpg["Join the community forum",link="https://community.gravitee.io?utm_source=readme", height=20]
 endif::[]
-
 
 == Description
 
@@ -18,7 +17,8 @@ The HTTP connector implements the SME Connector API in order to provide native i
 |===
 |Plugin version | APIM version
 
-|2.x and upper                  | 3.18.x to latest
-|1.1.x and upper                | 3.15.x to 3.17.x
-|1.0.x and upper                | 3.13.x to 3.14.x
+|3.x                            | 3.21.x to latest
+|2.x                            | 3.18.x to 3.20.x
+|1.1.x                          | 3.15.x to 3.17.x
+|1.0.x                          | 3.13.x to 3.14.x
 |===

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.gravitee</groupId>
         <artifactId>gravitee-parent</artifactId>
-        <version>20.0</version>
+        <version>21.0.0</version>
     </parent>
 
     <groupId>io.gravitee.connector</groupId>
@@ -34,11 +34,14 @@
     <name>Gravitee.io - Connector - HTTP</name>
 
     <properties>
-        <gravitee-bom.version>1.4</gravitee-bom.version>
-        <gravitee-common.version>1.27.0</gravitee-common.version>
+        <gravitee-bom.version>4.0.0</gravitee-bom.version>
+        <gravitee-common.version>2.1.0</gravitee-common.version>
         <gravitee-connector-api.version>1.1.5</gravitee-connector-api.version>
-        <gravitee-gateway-api.version>1.47.0</gravitee-gateway-api.version>
-        <gravitee-expression-language.version>1.11.4</gravitee-expression-language.version>
+        <gravitee-gateway-api.version>2.1.0</gravitee-gateway-api.version>
+        <gravitee-expression-language.version>2.1.1</gravitee-expression-language.version>
+
+        <maven-assembly-plugin.version>3.5.0</maven-assembly-plugin.version>
+        <prettier-maven-plugin.version>0.19</prettier-maven-plugin.version>
         <!-- Property used by the publication job in CI-->
         <publish-folder-path>graviteeio-apim/plugins/connectors</publish-folder-path>
     </properties>
@@ -134,7 +137,7 @@
         <plugins>
             <plugin>
                 <artifactId>maven-assembly-plugin</artifactId>
-                <version>3.3.0</version>
+                <version>${maven-assembly-plugin.version}</version>
                 <configuration>
                     <appendAssemblyId>false</appendAssemblyId>
                     <descriptors>
@@ -154,10 +157,9 @@
             <plugin>
                 <groupId>com.hubspot.maven.plugins</groupId>
                 <artifactId>prettier-maven-plugin</artifactId>
-                <version>0.18</version>
+                <version>${prettier-maven-plugin.version}</version>
                 <configuration>
-                    <nodeVersion>12.13.0</nodeVersion>
-                    <prettierJavaVersion>1.6.1</prettierJavaVersion>
+                    <prettierJavaVersion>2.1.0</prettierJavaVersion>
                     <skip>${skipTests}</skip>
                 </configuration>
                 <executions>

--- a/src/main/java/io/gravitee/connector/http/HttpConnection.java
+++ b/src/main/java/io/gravitee/connector/http/HttpConnection.java
@@ -198,7 +198,7 @@ public class HttpConnection<T extends HttpResponse> extends AbstractHttpConnecti
             response.cancelHandler(tracker);
 
             // Copy body content
-            clientResponse.handler(event -> response.bodyHandler().handle(Buffer.buffer(event.getBytes())));
+            clientResponse.handler(event -> response.bodyHandler().handle(Buffer.buffer(event)));
 
             // Signal end of the response
             clientResponse.endHandler(event -> {

--- a/src/test/java/io/gravitee/connector/http/stub/ThrowingOnGoAwayHttpConnection.java
+++ b/src/test/java/io/gravitee/connector/http/stub/ThrowingOnGoAwayHttpConnection.java
@@ -126,7 +126,17 @@ public class ThrowingOnGoAwayHttpConnection implements HttpConnection {
     }
 
     @Override
+    public SocketAddress remoteAddress(boolean real) {
+        return null;
+    }
+
+    @Override
     public SocketAddress localAddress() {
+        return null;
+    }
+
+    @Override
+    public SocketAddress localAddress(boolean real) {
         return null;
     }
 


### PR DESCRIPTION
**Description**

Reapply ByteBuf optimization and bump dependencies

Revert "fix: avoid chunk corruption with tls and http1.1" - commit a5da167.

BREAKING CHANGE: Need Vert.x `4.3.5` or higher due to this issue eclipse-vertx/vert.x#4509

<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `3.0.0-reapply-bytebuff-optimization-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/connector/gravitee-connector-http/3.0.0-reapply-bytebuff-optimization-SNAPSHOT/gravitee-connector-http-3.0.0-reapply-bytebuff-optimization-SNAPSHOT.zip)
  <!-- Version placeholder end -->
