### PR TITLE
fix: prevent sending unexpected headers to gRPC backend

### DIFF
--- a/src/main/java/io/gravitee/connector/http/HttpConnection.java
+++ b/src/main/java/io/gravitee/connector/http/HttpConnection.java
@@ -321,7 +321,7 @@ public class HttpConnection<T extends HttpResponse> extends AbstractHttpConnecti
             .headers()
             .names()
             .forEach(name -> {
-                httpClientRequest.headers().add(name, request.headers().getAll(name));
+                httpClientRequest.headers().set(name, request.headers().getAll(name));
             });
     }
 

--- a/src/main/java/io/gravitee/connector/http/HttpConnection.java
+++ b/src/main/java/io/gravitee/connector/http/HttpConnection.java
@@ -69,7 +69,7 @@ public class HttpConnection<T extends HttpResponse> extends AbstractHttpConnecti
         HOP_HEADERS = Collections.unmodifiableSet(hopHeaders);
     }
 
-    private HttpClientRequest httpClientRequest;
+    protected HttpClientRequest httpClientRequest;
     private final ProxyRequest request;
     private T response;
     private Handler<Throwable> timeoutHandler;

--- a/src/main/java/io/gravitee/connector/http/grpc/GrpcConnection.java
+++ b/src/main/java/io/gravitee/connector/http/grpc/GrpcConnection.java
@@ -24,6 +24,7 @@ import io.netty.handler.codec.http.HttpHeaderNames;
 import io.vertx.core.Future;
 import io.vertx.core.http.HttpClient;
 import io.vertx.core.http.HttpClientRequest;
+import io.vertx.core.http.HttpHeaders;
 import io.vertx.core.http.HttpMethod;
 import io.vertx.core.http.RequestOptions;
 
@@ -59,5 +60,13 @@ public class GrpcConnection extends HttpConnection<HttpResponse> {
                 // Always set chunked mode for gRPC transport
                 return httpClientRequest.setChunked(true);
             });
+    }
+
+    @Override
+    protected void writeUpstreamHeaders() {
+        super.writeUpstreamHeaders();
+
+        // Remove host header because gRPC is HTTP/2
+        httpClientRequest.headers().remove(HttpHeaders.HOST);
     }
 }


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/APIM-3675

**Description**

gRPC APIs were sending unexpected headers to gRPC backend:
- a duplicated `Content-Type` header
- the `Host` header

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `3.0.2-apim3675-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/connector/gravitee-connector-http/3.0.2-apim3675-SNAPSHOT/gravitee-connector-http-3.0.2-apim3675-SNAPSHOT.zip)
  <!-- Version placeholder end -->
