### PR TITLE
fix: detects websocket connection with multi-value connection header [2.x]

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,11 +34,12 @@
     <name>Gravitee.io - Connector - HTTP</name>
 
     <properties>
-        <gravitee-bom.version>1.4</gravitee-bom.version>
+        <gravitee-bom.version>3.0.19</gravitee-bom.version>
         <gravitee-common.version>1.27.0</gravitee-common.version>
         <gravitee-connector-api.version>1.1.5</gravitee-connector-api.version>
         <gravitee-gateway-api.version>1.47.0</gravitee-gateway-api.version>
         <gravitee-expression-language.version>1.11.4</gravitee-expression-language.version>
+
         <!-- Property used by the publication job in CI-->
         <publish-folder-path>graviteeio-apim/plugins/connectors</publish-folder-path>
     </properties>
@@ -108,10 +109,25 @@
             <artifactId>junit</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-params</artifactId>
+            <scope>test</scope>
+        </dependency>
 
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-junit-jupiter</artifactId>
             <scope>test</scope>
         </dependency>
 

--- a/src/main/java/io/gravitee/connector/http/HttpConnector.java
+++ b/src/main/java/io/gravitee/connector/http/HttpConnector.java
@@ -40,7 +40,7 @@ public class HttpConnector extends AbstractHttpConnector<HttpEndpoint> {
 
         boolean websocket =
             request.method() == HttpMethod.GET &&
-            HttpHeaderValues.UPGRADE.contentEqualsIgnoreCase(connectionHeader) &&
+            (connectionHeader != null && connectionHeader.toLowerCase().contains(HttpHeaderValues.UPGRADE)) &&
             HttpHeaderValues.WEBSOCKET.contentEqualsIgnoreCase(upgradeHeader);
 
         return websocket ? new WebSocketConnection(endpoint, request) : new HttpConnection<>(endpoint, request);


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/APIM-3776


**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `2.1.4-apim3776-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/connector/gravitee-connector-http/2.1.4-apim3776-SNAPSHOT/gravitee-connector-http-2.1.4-apim3776-SNAPSHOT.zip)
  <!-- Version placeholder end -->
