### PR TITLE
Configure Keep-alive timeout

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -170,10 +170,9 @@
             <plugin>
                 <groupId>com.hubspot.maven.plugins</groupId>
                 <artifactId>prettier-maven-plugin</artifactId>
-                <version>0.18</version>
+                <version>0.22</version>
                 <configuration>
-                    <nodeVersion>12.13.0</nodeVersion>
-                    <prettierJavaVersion>1.6.1</prettierJavaVersion>
+                    <prettierJavaVersion>2.6.0</prettierJavaVersion>
                     <skip>${skipTests}</skip>
                 </configuration>
                 <executions>

--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
 
     <groupId>io.gravitee.connector</groupId>
     <artifactId>gravitee-connector-http</artifactId>
-    <version>2.1.4</version>
+    <version>2.2.0-apim-3966-configure-keepalive-timeout-SNAPSHOT</version>
 
     <name>Gravitee.io - Connector - HTTP</name>
 

--- a/src/main/java/io/gravitee/connector/http/AbstractHttpConnector.java
+++ b/src/main/java/io/gravitee/connector/http/AbstractHttpConnector.java
@@ -184,6 +184,7 @@ public abstract class AbstractHttpConnector<E extends HttpEndpoint> extends Abst
         options.setPipelining(endpoint.getHttpClientOptions().isPipelining());
         options.setKeepAlive(endpoint.getHttpClientOptions().isKeepAlive());
         options.setIdleTimeout((int) (endpoint.getHttpClientOptions().getIdleTimeout() / 1000));
+        options.setKeepAliveTimeout((int) (endpoint.getHttpClientOptions().getKeepAliveTimeout() / 1000));
         options.setConnectTimeout((int) endpoint.getHttpClientOptions().getConnectTimeout());
         options.setMaxPoolSize(endpoint.getHttpClientOptions().getMaxConcurrentConnections());
         options.setTryUseCompression(endpoint.getHttpClientOptions().isUseCompression());
@@ -389,6 +390,9 @@ public abstract class AbstractHttpConnector<E extends HttpEndpoint> extends Abst
             '\'' +
             ", KeepAlive='" +
             options.isKeepAlive() +
+            '\'' +
+            ", KeepAliveTimeout='" +
+            options.getKeepAliveTimeout() +
             '\'' +
             ", IdleTimeout='" +
             options.getIdleTimeout() +

--- a/src/main/java/io/gravitee/connector/http/HttpConnection.java
+++ b/src/main/java/io/gravitee/connector/http/HttpConnection.java
@@ -145,12 +145,10 @@ public class HttpConnection<T extends HttpResponse> extends AbstractHttpConnecti
 
             if (
                 timeoutHandler() != null &&
-                (
-                    cause instanceof ConnectException ||
+                (cause instanceof ConnectException ||
                     cause instanceof TimeoutException ||
                     cause instanceof NoRouteToHostException ||
-                    cause instanceof UnknownHostException
-                )
+                    cause instanceof UnknownHostException)
             ) {
                 handleConnectTimeout(cause);
             } else {
@@ -218,8 +216,8 @@ public class HttpConnection<T extends HttpResponse> extends AbstractHttpConnecti
                 tracker.handle(null);
             });
 
-            clientResponse.customFrameHandler(frame ->
-                response.writeCustomFrame(HttpFrame.create(frame.type(), frame.flags(), Buffer.buffer(frame.payload())))
+            clientResponse.customFrameHandler(
+                frame -> response.writeCustomFrame(HttpFrame.create(frame.type(), frame.flags(), Buffer.buffer(frame.payload())))
             );
 
             // And send it to the client

--- a/src/main/java/io/gravitee/connector/http/endpoint/HttpClientOptions.java
+++ b/src/main/java/io/gravitee/connector/http/endpoint/HttpClientOptions.java
@@ -24,6 +24,7 @@ import java.io.Serializable;
 public class HttpClientOptions implements Serializable {
 
     public static long DEFAULT_IDLE_TIMEOUT = 60000;
+    public static long DEFAULT_KEEP_ALIVE_TIMEOUT = 30000;
     public static long DEFAULT_CONNECT_TIMEOUT = 5000;
     public static long DEFAULT_READ_TIMEOUT = 10000;
     public static int DEFAULT_MAX_CONCURRENT_CONNECTIONS = 100;
@@ -36,6 +37,8 @@ public class HttpClientOptions implements Serializable {
     public static ProtocolVersion DEFAULT_PROTOCOL_VERSION = ProtocolVersion.HTTP_1_1;
 
     private long idleTimeout = DEFAULT_IDLE_TIMEOUT;
+
+    private long keepAliveTimeout = DEFAULT_KEEP_ALIVE_TIMEOUT;
 
     private long connectTimeout = DEFAULT_CONNECT_TIMEOUT;
 
@@ -71,6 +74,14 @@ public class HttpClientOptions implements Serializable {
 
     public void setIdleTimeout(long idleTimeout) {
         this.idleTimeout = idleTimeout;
+    }
+
+    public long getKeepAliveTimeout() {
+        return keepAliveTimeout;
+    }
+
+    public void setKeepAliveTimeout(long keepAliveTimeout) {
+        this.keepAliveTimeout = keepAliveTimeout;
     }
 
     public boolean isKeepAlive() {

--- a/src/main/resources/schemas/schema-form.json
+++ b/src/main/resources/schemas/schema-form.json
@@ -69,20 +69,8 @@
         "idleTimeout": {
           "type": "integer",
           "title": "Idle timeout (ms)",
-          "description": "Maximum time a connection will timeout and be closed if no data is received within the timeout.",
+          "description": "Maximum time a connection will be opened if no data is received nor sent. Once the timeout has elapsed, the unused connection will be closed, allowing to free the associated resources.",
           "default": 60000
-        },
-        "followRedirects": {
-          "title": "Follow HTTP redirects",
-          "description": "When the client receives a status code in the range 3xx, it follows the redirection provided by the Location response header",
-          "type": "boolean",
-          "default": false
-        },
-        "maxConcurrentConnections": {
-          "type": "integer",
-          "title": "Max Concurrent Connections",
-          "description": "Maximum pool size for connections.",
-          "default": 100
         },
         "propagateClientAcceptEncoding": {
           "title": "Propagate client Accept-Encoding header (no decompression if any)",
@@ -98,9 +86,27 @@
               }
             ]
           }
+        },
+        "keepAliveTimeout": {
+          "type": "integer",
+          "title": "Keep-alive timeout (ms)",
+          "description": "Maximum time a connection will remain unused in the pool in milliseconds. Once the timeout has elapsed, the unused connection will be evicted.",
+          "default": 30000
+        },
+        "followRedirects": {
+          "title": "Follow HTTP redirects",
+          "description": "When the client receives a status code in the range 3xx, it follows the redirection provided by the Location response header",
+          "type": "boolean",
+          "default": false
+        },
+        "maxConcurrentConnections": {
+          "type": "integer",
+          "title": "Max Concurrent Connections",
+          "description": "Maximum pool size for connections.",
+          "default": 100
         }
       },
-      "required": ["connectTimeout", "readTimeout", "idleTimeout", "maxConcurrentConnections"]
+      "required": ["connectTimeout", "readTimeout", "idleTimeout", "keepAliveTimeout", "maxConcurrentConnections"]
     },
     "headers": {
       "type": "array",

--- a/src/test/java/io/gravitee/connector/http/HttpConnectorFactoryTest.java
+++ b/src/test/java/io/gravitee/connector/http/HttpConnectorFactoryTest.java
@@ -181,7 +181,9 @@ public class HttpConnectorFactoryTest {
 
         Connector<Connection, ProxyRequest> connector = factory.create(target, configuration, connectorBuilder);
         assertThat(connector).isInstanceOf(HttpConnector.class);
-        assertThat(((HttpConnector) connector).endpoint.getHeaders())
-            .containsExactly(new HttpHeader("X-Gravitee-Api", "test"), new HttpHeader("Empty-Header", ""));
+        assertThat(((HttpConnector) connector).endpoint.getHeaders()).containsExactly(
+            new HttpHeader("X-Gravitee-Api", "test"),
+            new HttpHeader("Empty-Header", "")
+        );
     }
 }

--- a/src/test/java/io/gravitee/connector/http/HttpConnectorTest.java
+++ b/src/test/java/io/gravitee/connector/http/HttpConnectorTest.java
@@ -119,13 +119,9 @@ public class HttpConnectorTest {
 
     @Test
     public void shouldOverrideHeaders() {
-        when(endpoint.getHeaders())
-            .thenReturn(
-                Arrays.asList(
-                    new HttpHeader(HttpHeaderNames.HOST, "api.gravitee.io"),
-                    new HttpHeader(HttpHeaderNames.HOST, "api2.gravitee.io")
-                )
-            );
+        when(endpoint.getHeaders()).thenReturn(
+            Arrays.asList(new HttpHeader(HttpHeaderNames.HOST, "api.gravitee.io"), new HttpHeader(HttpHeaderNames.HOST, "api2.gravitee.io"))
+        );
 
         connector.request(executionContext, request, connectionHandler);
 


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/APIM-3776

**Description**

Add the possibility to configure the Keep-Alive timeout

**New form display**
***HTTP 1.1 & Compression***
![image](https://github.com/gravitee-io/gravitee-connector-http/assets/13161768/054e361a-5b71-471b-b397-c9a871e7258b)

***HTTP 1.1 & No compression***
![image](https://github.com/gravitee-io/gravitee-connector-http/assets/13161768/baeff281-eaa6-49db-9ed7-1a58c43479a9)

***HTTP 2 & Compression***
![image](https://github.com/gravitee-io/gravitee-connector-http/assets/13161768/aab080fd-5869-4b86-9b32-564b91f29055)

***HTTP 2 & No compression***
![image](https://github.com/gravitee-io/gravitee-connector-http/assets/13161768/843a764c-7785-45a1-8c1c-6025cf7774ee)


<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `2.2.0-apim-3966-configure-keepalive-timeout-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/connector/gravitee-connector-http/2.2.0-apim-3966-configure-keepalive-timeout-SNAPSHOT/gravitee-connector-http-2.2.0-apim-3966-configure-keepalive-timeout-SNAPSHOT.zip)
  <!-- Version placeholder end -->
