### PR TITLE
make keepaliveTimeout not required

### DIFF
--- a/src/main/resources/schemas/schema-form.json
+++ b/src/main/resources/schemas/schema-form.json
@@ -106,7 +106,7 @@
           "default": 100
         }
       },
-      "required": ["connectTimeout", "readTimeout", "idleTimeout", "keepAliveTimeout", "maxConcurrentConnections"]
+      "required": ["connectTimeout", "readTimeout", "idleTimeout", "maxConcurrentConnections"]
     },
     "headers": {
       "type": "array",


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/APIM-3966

**Description**

Make keepaliveTimeout not required
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `2.2.1-fix-make-keepalivetimeout-not-required-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/connector/gravitee-connector-http/2.2.1-fix-make-keepalivetimeout-not-required-SNAPSHOT/gravitee-connector-http-2.2.1-fix-make-keepalivetimeout-not-required-SNAPSHOT.zip)
  <!-- Version placeholder end -->
