### PR TITLE
refactor: use gravitee-node VertxProxyOptionsUtils

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ version: 2.1
 setup: true
 
 orbs:
-    gravitee: gravitee-io/gravitee@2.1
+    gravitee: gravitee-io/gravitee@4.1.1
 
 # our single workflow, that triggers the setup job defined above, filters on tag and branches are needed otherwise
 # some workflow and job will not be triggered for tags (default CircleCI behavior)
@@ -22,7 +22,7 @@ workflows:
     setup_release:
         when:
             matches:
-                pattern: "^[0-9]+\\.[0-9]+\\.[0-9]+$"
+                pattern: "/^[0-9]+\\.[0-9]+\\.[0-9]+(-(alpha|beta|rc)\\.[0-9]+)?$/"
                 value: << pipeline.git.tag >>
         jobs:
             - gravitee/setup_plugin-release-config:
@@ -32,4 +32,4 @@ workflows:
                               - /.*/
                       tags:
                           only:
-                              - /^[0-9]+\.[0-9]+\.[0-9]+$/
+                              - /^[0-9]+\.[0-9]+\.[0-9]+(-(alpha|beta|rc)\.[0-9]+)?$/

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,13 +1,14 @@
-**Issue**
+## Issue
 
-https://github.com/gravitee-io/issues/issues/XXXXX
+https://gravitee.atlassian.net/browse/APIM-XXX
 
-**Description**
+## Description
 
 A small description of what you did in that PR.
 
-**Additional context**
+## Additional context
 
 <!-- Add any other context about the PR here -->
 <!-- It can be links to other PRs or docs or drawing -->
 <!-- Or reproduction steps in case of bug fix -->
+

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,14 +1,3 @@
 {
-  "extends": [
-    "config:base",
-    "schedule:earlyMondays"
-  ],
-  "prConcurrentLimit": 3,
-  "rebaseWhen": "conflicted",
-  "packageRules": [
-    {
-      "matchDatasources": ["orb"],
-      "rangeStrategy": "replace"
-    }
-  ]
+    "extends": ["github>gravitee-io/renovate-config:lib"]
 }

--- a/pom.xml
+++ b/pom.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+    Copyright © 2015 The Gravitee team (http://gravitee.io)
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,
@@ -24,24 +24,24 @@
     <parent>
         <groupId>io.gravitee</groupId>
         <artifactId>gravitee-parent</artifactId>
-        <version>21.0.0</version>
+        <version>22.0.22</version>
     </parent>
 
     <groupId>io.gravitee.connector</groupId>
     <artifactId>gravitee-connector-http</artifactId>
-    <version>3.1.1</version>
+    <version>4.0.0-apim-3800-refactor-vertx-proxy-options-SNAPSHOT</version>
 
     <name>Gravitee.io - Connector - HTTP</name>
 
     <properties>
-        <gravitee-bom.version>4.0.0</gravitee-bom.version>
-        <gravitee-common.version>2.1.0</gravitee-common.version>
+        <gravitee-bom.version>7.0.14</gravitee-bom.version>
+        <gravitee-common.version>4.0.0</gravitee-common.version>
         <gravitee-connector-api.version>1.1.5</gravitee-connector-api.version>
-        <gravitee-gateway-api.version>2.1.0</gravitee-gateway-api.version>
-        <gravitee-expression-language.version>2.1.1</gravitee-expression-language.version>
+        <gravitee-gateway-api.version>3.5.0</gravitee-gateway-api.version>
+        <gravitee-expression-language.version>3.1.0</gravitee-expression-language.version>
+        <gravitee-node.version>5.11.0</gravitee-node.version>
 
-        <maven-assembly-plugin.version>3.5.0</maven-assembly-plugin.version>
-        <prettier-maven-plugin.version>0.22</prettier-maven-plugin.version>
+        <maven-assembly-plugin.version>3.7.1</maven-assembly-plugin.version>
         <!-- Property used by the publication job in CI-->
         <publish-folder-path>graviteeio-apim/plugins/connectors</publish-folder-path>
     </properties>
@@ -83,6 +83,20 @@
             <groupId>io.gravitee.el</groupId>
             <artifactId>gravitee-expression-language</artifactId>
             <version>${gravitee-expression-language.version}</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.gravitee.node</groupId>
+            <artifactId>gravitee-node-api</artifactId>
+            <version>${gravitee-node.version}</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.gravitee.node</groupId>
+            <artifactId>gravitee-node-vertx</artifactId>
+            <version>${gravitee-node.version}</version>
             <scope>provided</scope>
         </dependency>
 
@@ -165,23 +179,6 @@
                         <phase>package</phase>
                         <goals>
                             <goal>single</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
-                <groupId>com.hubspot.maven.plugins</groupId>
-                <artifactId>prettier-maven-plugin</artifactId>
-                <version>${prettier-maven-plugin.version}</version>
-                <configuration>
-                    <prettierJavaVersion>2.6.0</prettierJavaVersion>
-                    <skip>${skipTests}</skip>
-                </configuration>
-                <executions>
-                    <execution>
-                        <phase>verify</phase>
-                        <goals>
-                            <goal>check</goal>
                         </goals>
                     </execution>
                 </executions>

--- a/src/assembly/assembly.xml
+++ b/src/assembly/assembly.xml
@@ -1,12 +1,12 @@
 <!--
 
-    Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+    Copyright © 2015 The Gravitee team (http://gravitee.io)
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/io/gravitee/connector/http/AbstractHttpConnection.java
+++ b/src/main/java/io/gravitee/connector/http/AbstractHttpConnection.java
@@ -1,11 +1,11 @@
-/**
- * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/io/gravitee/connector/http/AbstractHttpConnector.java
+++ b/src/main/java/io/gravitee/connector/http/AbstractHttpConnector.java
@@ -1,11 +1,11 @@
-/**
- * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -17,7 +17,6 @@ package io.gravitee.connector.http;
 
 import io.gravitee.common.http.HttpHeaders;
 import io.gravitee.common.util.MultiValueMap;
-import io.gravitee.common.util.VertxProxyOptionsUtils;
 import io.gravitee.connector.api.AbstractConnector;
 import io.gravitee.connector.api.Connection;
 import io.gravitee.connector.api.EndpointException;
@@ -35,6 +34,7 @@ import io.gravitee.gateway.api.ExecutionContext;
 import io.gravitee.gateway.api.handler.Handler;
 import io.gravitee.gateway.api.proxy.ProxyRequest;
 import io.gravitee.node.api.configuration.Configuration;
+import io.gravitee.node.vertx.proxy.VertxProxyOptionsUtils;
 import io.vertx.core.Vertx;
 import io.vertx.core.http.HttpClient;
 import io.vertx.core.http.HttpClientOptions;
@@ -440,7 +440,7 @@ public abstract class AbstractHttpConnector<E extends HttpEndpoint> extends Abst
 
     private void setSystemProxy(HttpClientOptions options) {
         try {
-            VertxProxyOptionsUtils.setSystemProxy(options, configuration);
+            options.setProxyOptions(VertxProxyOptionsUtils.buildProxyOptions(configuration));
         } catch (Exception e) {
             LOGGER.warn(
                 "A service endpoint (name[{}] type[{}] target[{}]) requires a system proxy to be defined but some configurations are missing or not well defined: {}",

--- a/src/main/java/io/gravitee/connector/http/HttpConnection.java
+++ b/src/main/java/io/gravitee/connector/http/HttpConnection.java
@@ -1,11 +1,11 @@
-/**
- * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -145,10 +145,12 @@ public class HttpConnection<T extends HttpResponse> extends AbstractHttpConnecti
 
             if (
                 timeoutHandler() != null &&
-                (cause instanceof ConnectException ||
+                (
+                    cause instanceof ConnectException ||
                     cause instanceof TimeoutException ||
                     cause instanceof NoRouteToHostException ||
-                    cause instanceof UnknownHostException)
+                    cause instanceof UnknownHostException
+                )
             ) {
                 handleConnectTimeout(cause);
             } else {
@@ -216,8 +218,8 @@ public class HttpConnection<T extends HttpResponse> extends AbstractHttpConnecti
                 tracker.handle(null);
             });
 
-            clientResponse.customFrameHandler(
-                frame -> response.writeCustomFrame(HttpFrame.create(frame.type(), frame.flags(), Buffer.buffer(frame.payload())))
+            clientResponse.customFrameHandler(frame ->
+                response.writeCustomFrame(HttpFrame.create(frame.type(), frame.flags(), Buffer.buffer(frame.payload())))
             );
 
             // And send it to the client

--- a/src/main/java/io/gravitee/connector/http/HttpConnector.java
+++ b/src/main/java/io/gravitee/connector/http/HttpConnector.java
@@ -1,11 +1,11 @@
-/**
- * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/io/gravitee/connector/http/HttpConnectorFactory.java
+++ b/src/main/java/io/gravitee/connector/http/HttpConnectorFactory.java
@@ -1,11 +1,11 @@
-/**
- * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/io/gravitee/connector/http/HttpResponse.java
+++ b/src/main/java/io/gravitee/connector/http/HttpResponse.java
@@ -1,11 +1,11 @@
-/**
- * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/io/gravitee/connector/http/endpoint/HttpClientOptions.java
+++ b/src/main/java/io/gravitee/connector/http/endpoint/HttpClientOptions.java
@@ -1,11 +1,11 @@
-/**
- * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/io/gravitee/connector/http/endpoint/HttpClientSslOptions.java
+++ b/src/main/java/io/gravitee/connector/http/endpoint/HttpClientSslOptions.java
@@ -1,11 +1,11 @@
-/**
- * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/io/gravitee/connector/http/endpoint/HttpEndpoint.java
+++ b/src/main/java/io/gravitee/connector/http/endpoint/HttpEndpoint.java
@@ -1,11 +1,11 @@
-/**
- * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/io/gravitee/connector/http/endpoint/HttpProxy.java
+++ b/src/main/java/io/gravitee/connector/http/endpoint/HttpProxy.java
@@ -1,11 +1,11 @@
-/**
- * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/io/gravitee/connector/http/endpoint/HttpProxyType.java
+++ b/src/main/java/io/gravitee/connector/http/endpoint/HttpProxyType.java
@@ -1,11 +1,11 @@
-/**
- * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/io/gravitee/connector/http/endpoint/KeyStore.java
+++ b/src/main/java/io/gravitee/connector/http/endpoint/KeyStore.java
@@ -1,11 +1,11 @@
-/**
- * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/io/gravitee/connector/http/endpoint/KeyStoreType.java
+++ b/src/main/java/io/gravitee/connector/http/endpoint/KeyStoreType.java
@@ -1,11 +1,11 @@
-/**
- * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/io/gravitee/connector/http/endpoint/ProtocolVersion.java
+++ b/src/main/java/io/gravitee/connector/http/endpoint/ProtocolVersion.java
@@ -1,11 +1,11 @@
-/**
- * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/io/gravitee/connector/http/endpoint/RequestOptions.java
+++ b/src/main/java/io/gravitee/connector/http/endpoint/RequestOptions.java
@@ -1,11 +1,11 @@
-/**
- * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/io/gravitee/connector/http/endpoint/TrustStore.java
+++ b/src/main/java/io/gravitee/connector/http/endpoint/TrustStore.java
@@ -1,11 +1,11 @@
-/**
- * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/io/gravitee/connector/http/endpoint/TrustStoreType.java
+++ b/src/main/java/io/gravitee/connector/http/endpoint/TrustStoreType.java
@@ -1,11 +1,11 @@
-/**
- * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/io/gravitee/connector/http/endpoint/factory/HttpEndpointFactory.java
+++ b/src/main/java/io/gravitee/connector/http/endpoint/factory/HttpEndpointFactory.java
@@ -1,11 +1,11 @@
-/**
- * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/io/gravitee/connector/http/endpoint/jks/JKSKeyStore.java
+++ b/src/main/java/io/gravitee/connector/http/endpoint/jks/JKSKeyStore.java
@@ -1,11 +1,11 @@
-/**
- * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/io/gravitee/connector/http/endpoint/jks/JKSTrustStore.java
+++ b/src/main/java/io/gravitee/connector/http/endpoint/jks/JKSTrustStore.java
@@ -1,11 +1,11 @@
-/**
- * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/io/gravitee/connector/http/endpoint/none/NoneKeyStore.java
+++ b/src/main/java/io/gravitee/connector/http/endpoint/none/NoneKeyStore.java
@@ -1,11 +1,11 @@
-/**
- * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/io/gravitee/connector/http/endpoint/none/NoneTrustStore.java
+++ b/src/main/java/io/gravitee/connector/http/endpoint/none/NoneTrustStore.java
@@ -1,11 +1,11 @@
-/**
- * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/io/gravitee/connector/http/endpoint/pem/PEMKeyStore.java
+++ b/src/main/java/io/gravitee/connector/http/endpoint/pem/PEMKeyStore.java
@@ -1,11 +1,11 @@
-/**
- * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/io/gravitee/connector/http/endpoint/pem/PEMTrustStore.java
+++ b/src/main/java/io/gravitee/connector/http/endpoint/pem/PEMTrustStore.java
@@ -1,11 +1,11 @@
-/**
- * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/io/gravitee/connector/http/endpoint/pkcs12/PKCS12KeyStore.java
+++ b/src/main/java/io/gravitee/connector/http/endpoint/pkcs12/PKCS12KeyStore.java
@@ -1,11 +1,11 @@
-/**
- * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/io/gravitee/connector/http/endpoint/pkcs12/PKCS12TrustStore.java
+++ b/src/main/java/io/gravitee/connector/http/endpoint/pkcs12/PKCS12TrustStore.java
@@ -1,11 +1,11 @@
-/**
- * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/io/gravitee/connector/http/grpc/GrpcConnection.java
+++ b/src/main/java/io/gravitee/connector/http/grpc/GrpcConnection.java
@@ -1,11 +1,11 @@
-/**
- * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/io/gravitee/connector/http/grpc/GrpcConnector.java
+++ b/src/main/java/io/gravitee/connector/http/grpc/GrpcConnector.java
@@ -1,11 +1,11 @@
-/**
- * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/io/gravitee/connector/http/vertx/VertxHttpHeaders.java
+++ b/src/main/java/io/gravitee/connector/http/vertx/VertxHttpHeaders.java
@@ -1,11 +1,11 @@
-/**
- * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/io/gravitee/connector/http/ws/SwitchProtocolProxyResponse.java
+++ b/src/main/java/io/gravitee/connector/http/ws/SwitchProtocolProxyResponse.java
@@ -1,11 +1,11 @@
-/**
- * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/io/gravitee/connector/http/ws/WebSocketConnection.java
+++ b/src/main/java/io/gravitee/connector/http/ws/WebSocketConnection.java
@@ -1,11 +1,11 @@
-/**
- * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -78,95 +78,98 @@ public class WebSocketConnection extends AbstractHttpConnection<HttpEndpoint> {
 
         wsProxyRequest.headers().forEach(entry -> options.addHeader(entry.getKey(), entry.getValue()));
 
-        httpClient.webSocket(options, event -> {
-            if (event.succeeded()) {
-                // The client -> gateway connection must be upgraded now that the one between gateway -> upstream
-                // has been accepted
-                wsProxyRequest
-                    .upgrade()
-                    .thenAccept(webSocketProxyRequest -> {
-                        // From server to client
-                        wsProxyRequest.frameHandler(frame -> {
-                            if (frame.type() == io.gravitee.gateway.api.ws.WebSocketFrame.Type.BINARY) {
-                                event
-                                    .result()
-                                    .writeFrame(
-                                        io.vertx.core.http.WebSocketFrame.binaryFrame(
-                                            io.vertx.core.buffer.Buffer.buffer(frame.data().getNativeBuffer()),
-                                            frame.isFinal()
-                                        )
-                                    );
-                            } else if (frame.type() == io.gravitee.gateway.api.ws.WebSocketFrame.Type.TEXT) {
-                                event
-                                    .result()
-                                    .writeFrame(io.vertx.core.http.WebSocketFrame.textFrame(frame.data().toString(), frame.isFinal()));
-                            } else if (frame.type() == io.gravitee.gateway.api.ws.WebSocketFrame.Type.CONTINUATION) {
-                                event
-                                    .result()
-                                    .writeFrame(
-                                        io.vertx.core.http.WebSocketFrame.continuationFrame(
-                                            io.vertx.core.buffer.Buffer.buffer(frame.data().toString()),
-                                            frame.isFinal()
-                                        )
-                                    );
-                            } else if (frame.type() == io.gravitee.gateway.api.ws.WebSocketFrame.Type.PING) {
-                                event
-                                    .result()
-                                    .writeFrame(
-                                        io.vertx.core.http.WebSocketFrame.pingFrame(
-                                            io.vertx.core.buffer.Buffer.buffer(frame.data().toString())
-                                        )
-                                    );
-                            } else if (frame.type() == io.gravitee.gateway.api.ws.WebSocketFrame.Type.PONG) {
-                                event
-                                    .result()
-                                    .writeFrame(
-                                        io.vertx.core.http.WebSocketFrame.pongFrame(
-                                            io.vertx.core.buffer.Buffer.buffer(frame.data().toString())
-                                        )
-                                    );
-                            }
+        httpClient.webSocket(
+            options,
+            event -> {
+                if (event.succeeded()) {
+                    // The client -> gateway connection must be upgraded now that the one between gateway -> upstream
+                    // has been accepted
+                    wsProxyRequest
+                        .upgrade()
+                        .thenAccept(webSocketProxyRequest -> {
+                            // From server to client
+                            wsProxyRequest.frameHandler(frame -> {
+                                if (frame.type() == io.gravitee.gateway.api.ws.WebSocketFrame.Type.BINARY) {
+                                    event
+                                        .result()
+                                        .writeFrame(
+                                            io.vertx.core.http.WebSocketFrame.binaryFrame(
+                                                io.vertx.core.buffer.Buffer.buffer(frame.data().getNativeBuffer()),
+                                                frame.isFinal()
+                                            )
+                                        );
+                                } else if (frame.type() == io.gravitee.gateway.api.ws.WebSocketFrame.Type.TEXT) {
+                                    event
+                                        .result()
+                                        .writeFrame(io.vertx.core.http.WebSocketFrame.textFrame(frame.data().toString(), frame.isFinal()));
+                                } else if (frame.type() == io.gravitee.gateway.api.ws.WebSocketFrame.Type.CONTINUATION) {
+                                    event
+                                        .result()
+                                        .writeFrame(
+                                            io.vertx.core.http.WebSocketFrame.continuationFrame(
+                                                io.vertx.core.buffer.Buffer.buffer(frame.data().toString()),
+                                                frame.isFinal()
+                                            )
+                                        );
+                                } else if (frame.type() == io.gravitee.gateway.api.ws.WebSocketFrame.Type.PING) {
+                                    event
+                                        .result()
+                                        .writeFrame(
+                                            io.vertx.core.http.WebSocketFrame.pingFrame(
+                                                io.vertx.core.buffer.Buffer.buffer(frame.data().toString())
+                                            )
+                                        );
+                                } else if (frame.type() == io.gravitee.gateway.api.ws.WebSocketFrame.Type.PONG) {
+                                    event
+                                        .result()
+                                        .writeFrame(
+                                            io.vertx.core.http.WebSocketFrame.pongFrame(
+                                                io.vertx.core.buffer.Buffer.buffer(frame.data().toString())
+                                            )
+                                        );
+                                }
+                            });
+
+                            wsProxyRequest.closeHandler(result -> event.result().close());
+
+                            // From client to server
+                            event.result().frameHandler(frame -> wsProxyRequest.write(new WebSocketFrame(frame)));
+
+                            event
+                                .result()
+                                .closeHandler(event1 -> {
+                                    wsProxyRequest.close();
+                                    tracker.handle(null);
+                                });
+
+                            event
+                                .result()
+                                .exceptionHandler(throwable -> {
+                                    wsProxyRequest.reject(HttpStatusCode.BAD_REQUEST_400);
+                                    sendToClient(new StatusResponse(HttpStatusCode.BAD_REQUEST_400));
+                                    tracker.handle(null);
+                                });
+
+                            connectionHandler.handle(null);
+
+                            // Tell the reactor that the request has been handled by the HTTP client
+                            sendToClient(new SwitchProtocolProxyResponse());
                         });
-
-                        wsProxyRequest.closeHandler(result -> event.result().close());
-
-                        // From client to server
-                        event.result().frameHandler(frame -> wsProxyRequest.write(new WebSocketFrame(frame)));
-
-                        event
-                            .result()
-                            .closeHandler(event1 -> {
-                                wsProxyRequest.close();
-                                tracker.handle(null);
-                            });
-
-                        event
-                            .result()
-                            .exceptionHandler(throwable -> {
-                                wsProxyRequest.reject(HttpStatusCode.BAD_REQUEST_400);
-                                sendToClient(new StatusResponse(HttpStatusCode.BAD_REQUEST_400));
-                                tracker.handle(null);
-                            });
-
-                        connectionHandler.handle(null);
-
-                        // Tell the reactor that the request has been handled by the HTTP client
-                        sendToClient(new SwitchProtocolProxyResponse());
-                    });
-            } else {
-                connectionHandler.handle(null);
-
-                if (event.cause() instanceof UpgradeRejectedException) {
-                    wsProxyRequest.reject(((UpgradeRejectedException) event.cause()).getStatus());
-                    sendToClient(new StatusResponse(((UpgradeRejectedException) event.cause()).getStatus()));
                 } else {
-                    wsProxyRequest.reject(HttpStatusCode.BAD_GATEWAY_502);
-                    sendToClient(new StatusResponse(HttpStatusCode.BAD_GATEWAY_502));
-                }
+                    connectionHandler.handle(null);
 
-                tracker.handle(null);
+                    if (event.cause() instanceof UpgradeRejectedException) {
+                        wsProxyRequest.reject(((UpgradeRejectedException) event.cause()).getStatus());
+                        sendToClient(new StatusResponse(((UpgradeRejectedException) event.cause()).getStatus()));
+                    } else {
+                        wsProxyRequest.reject(HttpStatusCode.BAD_GATEWAY_502);
+                        sendToClient(new StatusResponse(HttpStatusCode.BAD_GATEWAY_502));
+                    }
+
+                    tracker.handle(null);
+                }
             }
-        });
+        );
     }
 
     @Override

--- a/src/main/java/io/gravitee/connector/http/ws/WebSocketFrame.java
+++ b/src/main/java/io/gravitee/connector/http/ws/WebSocketFrame.java
@@ -1,11 +1,11 @@
-/**
- * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/resources/schemas/schema-form.json
+++ b/src/main/resources/schemas/schema-form.json
@@ -1,581 +1,581 @@
 {
-  "type": "object",
-  "id": "urn:jsonschema:io:gravitee:connector:http:configuration:HttpConnectorConfiguration",
-  "properties": {
-    "http": {
-      "type": "object",
-      "title": "HTTP Options",
-      "id": "urn:jsonschema:io:gravitee:connector:http:configuration:HttpOptions",
-      "properties": {
-        "clearTextUpgrade": {
-          "title": "Allow h2c Clear Text Upgrade",
-          "description": "If enabled, an h2c connection is established using an HTTP/1.1 Upgrade request. If disabled, h2c connection is established directly (with prior knowledge) ",
-          "type": "boolean",
-          "default": true,
-          "x-schema-form": {
-            "hidden": [
-              {
-                "$eq": {
-                  "http.version": "HTTP_1_1"
+    "type": "object",
+    "id": "urn:jsonschema:io:gravitee:connector:http:configuration:HttpConnectorConfiguration",
+    "properties": {
+        "http": {
+            "type": "object",
+            "title": "HTTP Options",
+            "id": "urn:jsonschema:io:gravitee:connector:http:configuration:HttpOptions",
+            "properties": {
+                "clearTextUpgrade": {
+                    "title": "Allow h2c Clear Text Upgrade",
+                    "description": "If enabled, an h2c connection is established using an HTTP/1.1 Upgrade request. If disabled, h2c connection is established directly (with prior knowledge) ",
+                    "type": "boolean",
+                    "default": true,
+                    "x-schema-form": {
+                        "hidden": [
+                            {
+                                "$eq": {
+                                    "http.version": "HTTP_1_1"
+                                }
+                            }
+                        ]
+                    }
+                },
+                "version": {
+                    "title": "HTTP Protocol version",
+                    "description": "The version of the HTTP protocol to use",
+                    "type": "string",
+                    "default": "HTTP_1_1",
+                    "enum": ["HTTP_1_1", "HTTP_2"],
+                    "x-schema-form": {
+                        "type": "select",
+                        "titleMap": {
+                            "HTTP_1_1": "HTTP 1.1",
+                            "HTTP_2": "HTTP 2"
+                        }
+                    }
+                },
+                "keepAlive": {
+                    "title": "Enable keep-alive",
+                    "description": "Use an HTTP persistent connection to send and receive multiple HTTP requests / responses.",
+                    "type": "boolean",
+                    "default": true
+                },
+                "connectTimeout": {
+                    "type": "integer",
+                    "title": "Connect timeout (ms)",
+                    "description": "Maximum time to connect to the remote host.",
+                    "default": 5000
+                },
+                "pipelining": {
+                    "title": "Enable HTTP pipelining",
+                    "description": "When pipe-lining is enabled requests will be written to connections without waiting for previous responses to return.\n",
+                    "type": "boolean",
+                    "default": false
+                },
+                "readTimeout": {
+                    "type": "integer",
+                    "title": "Read timeout (ms)",
+                    "description": "Maximum time to complete the request (including response).",
+                    "default": 10000
+                },
+                "useCompression": {
+                    "title": "Enable compression (gzip, deflate)",
+                    "description": "The gateway can let the remote http server know that it supports compression. In case the remote http server returns a compressed response, the gateway will decompress it. Leave that option off if you don't want compression between the gateway and the remote server.",
+                    "type": "boolean",
+                    "default": true
+                },
+                "idleTimeout": {
+                    "type": "integer",
+                    "title": "Idle timeout (ms)",
+                    "description": "Maximum time a connection will be opened if no data is received nor sent. Once the timeout has elapsed, the unused connection will be closed, allowing to free the associated resources.",
+                    "default": 60000
+                },
+                "propagateClientAcceptEncoding": {
+                    "title": "Propagate client Accept-Encoding header (no decompression if any)",
+                    "description": "The gateway will propagate the Accept-Encoding header's value specified by the client's request to the backend (if any). The gateway will <b>NEVER attempt to decompress the content</b> if the backend response is compressed (gzip, deflate). It is then not possible to apply transformation policy if the body is compressed. Also, body will appear compressed if logging is enabled for the API. <b>DO NOT</b> activate this option if you plan to play with body responses.",
+                    "type": "boolean",
+                    "default": false,
+                    "x-schema-form": {
+                        "hidden": [
+                            {
+                                "$eq": {
+                                    "http.useCompression": true
+                                }
+                            }
+                        ]
+                    }
+                },
+                "keepAliveTimeout": {
+                    "type": "integer",
+                    "title": "Keep-alive timeout (ms)",
+                    "description": "Maximum time a connection will remain unused in the pool in milliseconds. Once the timeout has elapsed, the unused connection will be evicted.",
+                    "default": 30000
+                },
+                "followRedirects": {
+                    "title": "Follow HTTP redirects",
+                    "description": "When the client receives a status code in the range 3xx, it follows the redirection provided by the Location response header",
+                    "type": "boolean",
+                    "default": false
+                },
+                "maxConcurrentConnections": {
+                    "type": "integer",
+                    "title": "Max Concurrent Connections",
+                    "description": "Maximum pool size for connections.",
+                    "default": 100
                 }
-              }
-            ]
-          }
+            },
+            "required": ["connectTimeout", "readTimeout", "idleTimeout", "maxConcurrentConnections"]
         },
-        "version": {
-          "title": "HTTP Protocol version",
-          "description": "The version of the HTTP protocol to use",
-          "type": "string",
-          "default": "HTTP_1_1",
-          "enum": ["HTTP_1_1", "HTTP_2"],
-          "x-schema-form": {
-            "type": "select",
-            "titleMap": {
-              "HTTP_1_1": "HTTP 1.1",
-              "HTTP_2": "HTTP 2"
+        "headers": {
+            "type": "array",
+            "title": "HTTP Headers",
+            "description": "Default HTTP headers added or overridden by the API gateway to upstream",
+            "items": {
+                "type": "object",
+                "title": "Header",
+                "id": "urn:jsonschema:io:gravitee:connector:http:configuration:HttpHeader",
+                "properties": {
+                    "name": {
+                        "type": "string",
+                        "title": "Name"
+                    },
+                    "value": {
+                        "type": "string",
+                        "title": "Value"
+                    }
+                },
+                "required": ["name", "value"]
             }
-          }
         },
-        "keepAlive": {
-          "title": "Enable keep-alive",
-          "description": "Use an HTTP persistent connection to send and receive multiple HTTP requests / responses.",
-          "type": "boolean",
-          "default": true
-        },
-        "connectTimeout": {
-          "type": "integer",
-          "title": "Connect timeout (ms)",
-          "description": "Maximum time to connect to the remote host.",
-          "default": 5000
-        },
-        "pipelining": {
-          "title": "Enable HTTP pipelining",
-          "description": "When pipe-lining is enabled requests will be written to connections without waiting for previous responses to return.\n",
-          "type": "boolean",
-          "default": false
-        },
-        "readTimeout": {
-          "type": "integer",
-          "title": "Read timeout (ms)",
-          "description": "Maximum time to complete the request (including response).",
-          "default": 10000
-        },
-        "useCompression": {
-          "title": "Enable compression (gzip, deflate)",
-          "description": "The gateway can let the remote http server know that it supports compression. In case the remote http server returns a compressed response, the gateway will decompress it. Leave that option off if you don't want compression between the gateway and the remote server.",
-          "type": "boolean",
-          "default": true
-        },
-        "idleTimeout": {
-          "type": "integer",
-          "title": "Idle timeout (ms)",
-          "description": "Maximum time a connection will be opened if no data is received nor sent. Once the timeout has elapsed, the unused connection will be closed, allowing to free the associated resources.",
-          "default": 60000
-        },
-        "propagateClientAcceptEncoding": {
-          "title": "Propagate client Accept-Encoding header (no decompression if any)",
-          "description": "The gateway will propagate the Accept-Encoding header's value specified by the client's request to the backend (if any). The gateway will <b>NEVER attempt to decompress the content</b> if the backend response is compressed (gzip, deflate). It is then not possible to apply transformation policy if the body is compressed. Also, body will appear compressed if logging is enabled for the API. <b>DO NOT</b> activate this option if you plan to play with body responses.",
-          "type": "boolean",
-          "default": false,
-          "x-schema-form": {
-            "hidden": [
-              {
-                "$eq": {
-                  "http.useCompression": true
+        "proxy": {
+            "type": "object",
+            "title": "Proxy Options",
+            "id": "urn:jsonschema:io:gravitee:connector:http:configuration:HttpProxyOptions",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "title": "Use proxy",
+                    "description": "Use proxy for client connections",
+                    "default": false
+                },
+                "type": {
+                    "type": "string",
+                    "title": "Proxy Type",
+                    "description": "The type of the proxy",
+                    "default": "HTTP",
+                    "enum": ["HTTP", "SOCKS4", "SOCKS5"],
+                    "x-schema-form": {
+                        "type": "select",
+                        "titleMap": {
+                            "HTTP": "HTTP CONNECT proxy",
+                            "SOCKS4": "SOCKS4/4a tcp proxy",
+                            "SOCKS5": "SOCKS5 tcp proxy"
+                        },
+                        "hidden": [
+                            {
+                                "$eq": {
+                                    "proxy.enabled": false
+                                }
+                            }
+                        ],
+                        "disabled": [
+                            {
+                                "$eq": {
+                                    "proxy.useSystemProxy": true
+                                }
+                            }
+                        ]
+                    }
+                },
+                "useSystemProxy": {
+                    "type": "boolean",
+                    "title": "Use system proxy",
+                    "description": "Use proxy configured at system level",
+                    "default": false,
+                    "x-schema-form": {
+                        "hidden": [
+                            {
+                                "$eq": {
+                                    "proxy.enabled": false
+                                }
+                            }
+                        ]
+                    }
+                },
+                "host": {
+                    "type": "string",
+                    "title": "Proxy host",
+                    "description": "Proxy host to connect to",
+                    "x-schema-form": {
+                        "hidden": [
+                            {
+                                "$eq": {
+                                    "proxy.enabled": false
+                                }
+                            }
+                        ],
+                        "disabled": [
+                            {
+                                "$eq": {
+                                    "proxy.useSystemProxy": true
+                                }
+                            }
+                        ]
+                    }
+                },
+                "port": {
+                    "type": "integer",
+                    "title": "Proxy port",
+                    "description": "Proxy port to connect to",
+                    "x-schema-form": {
+                        "hidden": [
+                            {
+                                "$eq": {
+                                    "proxy.enabled": false
+                                }
+                            }
+                        ],
+                        "disabled": [
+                            {
+                                "$eq": {
+                                    "proxy.useSystemProxy": true
+                                }
+                            }
+                        ]
+                    }
+                },
+                "username": {
+                    "type": "string",
+                    "title": "Proxy username",
+                    "description": "Optional proxy username",
+                    "x-schema-form": {
+                        "hidden": [
+                            {
+                                "$eq": {
+                                    "proxy.enabled": false
+                                }
+                            }
+                        ],
+                        "disabled": [
+                            {
+                                "$eq": {
+                                    "proxy.useSystemProxy": true
+                                }
+                            }
+                        ]
+                    }
+                },
+                "password": {
+                    "type": "string",
+                    "title": "Proxy password",
+                    "description": "Optional proxy password",
+                    "x-schema-form": {
+                        "type": "password",
+                        "hidden": [
+                            {
+                                "$eq": {
+                                    "proxy.enabled": false
+                                }
+                            }
+                        ],
+                        "disabled": [
+                            {
+                                "$eq": {
+                                    "proxy.useSystemProxy": true
+                                }
+                            }
+                        ]
+                    }
                 }
-              }
+            },
+            "oneOf": [
+                {
+                    "properties": { "enabled": { "const": false } }
+                },
+                {
+                    "properties": { "enabled": { "const": true }, "useSystemProxy": { "const": true } }
+                },
+                {
+                    "properties": { "enabled": { "const": true }, "useSystemProxy": { "const": false } },
+                    "required": ["host", "port"]
+                }
             ]
-          }
         },
-        "keepAliveTimeout": {
-          "type": "integer",
-          "title": "Keep-alive timeout (ms)",
-          "description": "Maximum time a connection will remain unused in the pool in milliseconds. Once the timeout has elapsed, the unused connection will be evicted.",
-          "default": 30000
-        },
-        "followRedirects": {
-          "title": "Follow HTTP redirects",
-          "description": "When the client receives a status code in the range 3xx, it follows the redirection provided by the Location response header",
-          "type": "boolean",
-          "default": false
-        },
-        "maxConcurrentConnections": {
-          "type": "integer",
-          "title": "Max Concurrent Connections",
-          "description": "Maximum pool size for connections.",
-          "default": 100
+        "ssl": {
+            "type": "object",
+            "title": "SSL Options",
+            "id": "urn:jsonschema:io:gravitee:connector:http:configuration:SslOptions",
+            "properties": {
+                "hostnameVerifier": {
+                    "title": "Verify Host",
+                    "description": "Use to enable host name verification",
+                    "type": "boolean",
+                    "default": false
+                },
+                "trustAll": {
+                    "title": "Trust all",
+                    "description": "Use this with caution (if over Internet). The gateway must trust any origin certificates. The connection will still be encrypted but this mode is vulnerable to 'man in the middle' attacks.",
+                    "type": "boolean",
+                    "default": false
+                },
+                "trustStore": {
+                    "type": "object",
+                    "title": "Trust store",
+                    "id": "urn:jsonschema:io:gravitee:connector:http:configuration:SslTrustStoreOptions",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "title": "Type",
+                            "description": "The type of the trust store",
+                            "default": "",
+                            "enum": ["", "JKS", "PKCS12", "PEM"],
+                            "x-schema-form": {
+                                "type": "select",
+                                "titleMap": {
+                                    "": "None",
+                                    "JKS": "Java Trust Store (.jks)",
+                                    "PKCS12": "PKCS#12 (.p12) / PFX (.pfx)",
+                                    "PEM": "PEM (.pem)"
+                                }
+                            }
+                        },
+                        "password": {
+                            "type": "string",
+                            "title": "Password",
+                            "description": "Trust store password",
+                            "x-schema-form": {
+                                "type": "password",
+                                "hidden": [
+                                    {
+                                        "$eq": {
+                                            "ssl.trustStore.type": ["", "PEM"]
+                                        }
+                                    }
+                                ]
+                            }
+                        },
+                        "path": {
+                            "type": "string",
+                            "title": "Path to trust store",
+                            "description": "Path to the trust store file",
+                            "x-schema-form": {
+                                "hidden": [
+                                    {
+                                        "$eq": {
+                                            "ssl.trustStore.type": ""
+                                        }
+                                    }
+                                ]
+                            }
+                        },
+                        "content": {
+                            "type": "string",
+                            "title": "Content",
+                            "description": "Binary content as Base64",
+                            "x-schema-form": {
+                                "type": "text",
+                                "hidden": [
+                                    {
+                                        "$eq": {
+                                            "ssl.trustStore.type": ""
+                                        }
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "oneOf": [
+                        {
+                            "properties": { "type": { "const": "" } }
+                        },
+                        {
+                            "properties": { "type": { "const": "PEM" } },
+                            "required": ["content"]
+                        },
+                        {
+                            "properties": { "type": { "const": "PEM" } },
+                            "required": ["path"]
+                        },
+                        {
+                            "properties": { "type": { "pattern": "JKS|PKCS12" } },
+                            "required": ["content", "password"]
+                        },
+                        {
+                            "properties": { "type": { "pattern": "JKS|PKCS12" } },
+                            "required": ["path", "password"]
+                        }
+                    ],
+                    "x-schema-form": {
+                        "hidden": [
+                            {
+                                "$eq": {
+                                    "ssl.trustAll": true
+                                }
+                            }
+                        ]
+                    }
+                },
+                "keyStore": {
+                    "type": "object",
+                    "title": "Key store",
+                    "id": "urn:jsonschema:io:gravitee:connector:http:configuration:SslKeyStoreOptions",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "title": "Type",
+                            "description": "The type of the key store",
+                            "default": "",
+                            "enum": ["", "JKS", "PKCS12", "PEM"],
+                            "x-schema-form": {
+                                "type": "select",
+                                "titleMap": {
+                                    "": "None",
+                                    "JKS": "Java Trust Store (.jks)",
+                                    "PKCS12": "PKCS#12 (.p12) / PFX (.pfx)",
+                                    "PEM": "PEM (.pem)"
+                                }
+                            }
+                        },
+                        "password": {
+                            "type": "string",
+                            "title": "Password",
+                            "description": "Key store password",
+                            "x-schema-form": {
+                                "type": "password",
+                                "hidden": [
+                                    {
+                                        "$eq": {
+                                            "ssl.keyStore.type": ["", "PEM"]
+                                        }
+                                    }
+                                ]
+                            }
+                        },
+                        "path": {
+                            "type": "string",
+                            "title": "Path to key store",
+                            "description": "Path to the key store file",
+                            "x-schema-form": {
+                                "hidden": [
+                                    {
+                                        "$eq": {
+                                            "ssl.keyStore.type": ["", "PEM"]
+                                        }
+                                    }
+                                ]
+                            }
+                        },
+                        "content": {
+                            "type": "string",
+                            "title": "Content",
+                            "description": "Binary content as Base64",
+                            "x-schema-form": {
+                                "type": "text",
+                                "hidden": [
+                                    {
+                                        "$eq": {
+                                            "ssl.keyStore.type": ["", "PEM"]
+                                        }
+                                    }
+                                ]
+                            }
+                        },
+                        "certPath": {
+                            "type": "string",
+                            "title": "Path to cert file",
+                            "description": "Path to cert file (.PEM)",
+                            "x-schema-form": {
+                                "hidden": [
+                                    {
+                                        "$neq": {
+                                            "ssl.keyStore.type": "PEM"
+                                        }
+                                    }
+                                ]
+                            }
+                        },
+                        "certContent": {
+                            "type": "string",
+                            "title": "Certificate",
+                            "x-schema-form": {
+                                "type": "text",
+                                "hidden": [
+                                    {
+                                        "$neq": {
+                                            "ssl.keyStore.type": "PEM"
+                                        }
+                                    }
+                                ]
+                            }
+                        },
+                        "keyPath": {
+                            "type": "string",
+                            "title": "Path to private key file",
+                            "description": "Path to private key file (.PEM)",
+                            "x-schema-form": {
+                                "hidden": [
+                                    {
+                                        "$neq": {
+                                            "ssl.keyStore.type": "PEM"
+                                        }
+                                    }
+                                ]
+                            }
+                        },
+                        "keyContent": {
+                            "type": "string",
+                            "title": "Private key",
+                            "x-schema-form": {
+                                "type": "text",
+                                "hidden": [
+                                    {
+                                        "$neq": {
+                                            "ssl.keyStore.type": "PEM"
+                                        }
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "oneOf": [
+                        {
+                            "properties": { "type": { "const": "" } }
+                        },
+                        {
+                            "properties": { "type": { "const": "PEM" } },
+                            "required": ["certContent", "keyContent"]
+                        },
+                        {
+                            "properties": { "type": { "const": "PEM" } },
+                            "required": ["certPath", "keyPath"]
+                        },
+                        {
+                            "properties": { "type": { "const": "PEM" } },
+                            "required": ["certContent", "keyPath"]
+                        },
+                        {
+                            "properties": { "type": { "const": "PEM" } },
+                            "required": ["certPath", "keyContent"]
+                        },
+                        {
+                            "properties": { "type": { "pattern": "JKS|PKCS12" } },
+                            "required": ["content", "password"]
+                        },
+                        {
+                            "properties": { "type": { "pattern": "JKS|PKCS12" } },
+                            "required": ["path", "password"]
+                        }
+                    ]
+                }
+            }
         }
-      },
-      "required": ["connectTimeout", "readTimeout", "idleTimeout", "maxConcurrentConnections"]
     },
-    "headers": {
-      "type": "array",
-      "title": "HTTP Headers",
-      "description": "Default HTTP headers added or overridden by the API gateway to upstream",
-      "items": {
-        "type": "object",
-        "title": "Header",
-        "id": "urn:jsonschema:io:gravitee:connector:http:configuration:HttpHeader",
-        "properties": {
-          "name": {
-            "type": "string",
-            "title": "Name"
-          },
-          "value": {
-            "type": "string",
-            "title": "Value"
-          }
-        },
-        "required": ["name", "value"]
-      }
+    "additionalProperties": false,
+    "patternProperties": {
+        "backup": true,
+        "healthcheck": true,
+        "inherit": true,
+        "name": true,
+        "target": true,
+        "tenants": true,
+        "type": true,
+        "weight": true
     },
-    "proxy": {
-      "type": "object",
-      "title": "Proxy Options",
-      "id": "urn:jsonschema:io:gravitee:connector:http:configuration:HttpProxyOptions",
-      "properties": {
-        "enabled": {
-          "type": "boolean",
-          "title": "Use proxy",
-          "description": "Use proxy for client connections",
-          "default": false
-        },
-        "type": {
-          "type": "string",
-          "title": "Proxy Type",
-          "description": "The type of the proxy",
-          "default": "HTTP",
-          "enum": ["HTTP", "SOCKS4", "SOCKS5"],
-          "x-schema-form": {
-            "type": "select",
-            "titleMap": {
-              "HTTP": "HTTP CONNECT proxy",
-              "SOCKS4": "SOCKS4/4a tcp proxy",
-              "SOCKS5": "SOCKS5 tcp proxy"
+    "x-schema-form": {
+        "errors": {
+            "proxy": {
+                "oneOf": "The host and port are <span class=\"error\">required</span>"
             },
-            "hidden": [
-              {
-                "$eq": {
-                  "proxy.enabled": false
+            "ssl": {
+                "trustStore": {
+                    "oneOf": "A path or a content is <span class=\"error\">required</span> - for JKS and PKCS#12 a password is also <span class=\"error\">required</span>"
+                },
+                "keyStore": {
+                    "oneOf": "Paths or contents are <span class=\"error\">required</span> - for JKS and PKCS#12, a password is also <span class=\"error\">required</span>."
                 }
-              }
-            ],
-            "disabled": [
-              {
-                "$eq": {
-                  "proxy.useSystemProxy": true
-                }
-              }
-            ]
-          }
-        },
-        "useSystemProxy": {
-          "type": "boolean",
-          "title": "Use system proxy",
-          "description": "Use proxy configured at system level",
-          "default": false,
-          "x-schema-form": {
-            "hidden": [
-              {
-                "$eq": {
-                  "proxy.enabled": false
-                }
-              }
-            ]
-          }
-        },
-        "host": {
-          "type": "string",
-          "title": "Proxy host",
-          "description": "Proxy host to connect to",
-          "x-schema-form": {
-            "hidden": [
-              {
-                "$eq": {
-                  "proxy.enabled": false
-                }
-              }
-            ],
-            "disabled": [
-              {
-                "$eq": {
-                  "proxy.useSystemProxy": true
-                }
-              }
-            ]
-          }
-        },
-        "port": {
-          "type": "integer",
-          "title": "Proxy port",
-          "description": "Proxy port to connect to",
-          "x-schema-form": {
-            "hidden": [
-              {
-                "$eq": {
-                  "proxy.enabled": false
-                }
-              }
-            ],
-            "disabled": [
-              {
-                "$eq": {
-                  "proxy.useSystemProxy": true
-                }
-              }
-            ]
-          }
-        },
-        "username": {
-          "type": "string",
-          "title": "Proxy username",
-          "description": "Optional proxy username",
-          "x-schema-form": {
-            "hidden": [
-              {
-                "$eq": {
-                  "proxy.enabled": false
-                }
-              }
-            ],
-            "disabled": [
-              {
-                "$eq": {
-                  "proxy.useSystemProxy": true
-                }
-              }
-            ]
-          }
-        },
-        "password": {
-          "type": "string",
-          "title": "Proxy password",
-          "description": "Optional proxy password",
-          "x-schema-form": {
-            "type": "password",
-            "hidden": [
-              {
-                "$eq": {
-                  "proxy.enabled": false
-                }
-              }
-            ],
-            "disabled": [
-              {
-                "$eq": {
-                  "proxy.useSystemProxy": true
-                }
-              }
-            ]
-          }
+            }
         }
-      },
-      "oneOf": [
-        {
-          "properties": { "enabled": { "const": false } }
-        },
-        {
-          "properties": { "enabled": { "const": true }, "useSystemProxy": { "const": true } }
-        },
-        {
-          "properties": { "enabled": { "const": true }, "useSystemProxy": { "const": false } },
-          "required": ["host", "port"]
-        }
-      ]
-    },
-    "ssl": {
-      "type": "object",
-      "title": "SSL Options",
-      "id": "urn:jsonschema:io:gravitee:connector:http:configuration:SslOptions",
-      "properties": {
-        "hostnameVerifier": {
-          "title": "Verify Host",
-          "description": "Use to enable host name verification",
-          "type": "boolean",
-          "default": false
-        },
-        "trustAll": {
-          "title": "Trust all",
-          "description": "Use this with caution (if over Internet). The gateway must trust any origin certificates. The connection will still be encrypted but this mode is vulnerable to 'man in the middle' attacks.",
-          "type": "boolean",
-          "default": false
-        },
-        "trustStore": {
-          "type": "object",
-          "title": "Trust store",
-          "id": "urn:jsonschema:io:gravitee:connector:http:configuration:SslTrustStoreOptions",
-          "properties": {
-            "type": {
-              "type": "string",
-              "title": "Type",
-              "description": "The type of the trust store",
-              "default": "",
-              "enum": ["", "JKS", "PKCS12", "PEM"],
-              "x-schema-form": {
-                "type": "select",
-                "titleMap": {
-                  "": "None",
-                  "JKS": "Java Trust Store (.jks)",
-                  "PKCS12": "PKCS#12 (.p12) / PFX (.pfx)",
-                  "PEM": "PEM (.pem)"
-                }
-              }
-            },
-            "password": {
-              "type": "string",
-              "title": "Password",
-              "description": "Trust store password",
-              "x-schema-form": {
-                "type": "password",
-                "hidden": [
-                  {
-                    "$eq": {
-                      "ssl.trustStore.type": ["", "PEM"]
-                    }
-                  }
-                ]
-              }
-            },
-            "path": {
-              "type": "string",
-              "title": "Path to trust store",
-              "description": "Path to the trust store file",
-              "x-schema-form": {
-                "hidden": [
-                  {
-                    "$eq": {
-                      "ssl.trustStore.type": ""
-                    }
-                  }
-                ]
-              }
-            },
-            "content": {
-              "type": "string",
-              "title": "Content",
-              "description": "Binary content as Base64",
-              "x-schema-form": {
-                "type": "text",
-                "hidden": [
-                  {
-                    "$eq": {
-                      "ssl.trustStore.type": ""
-                    }
-                  }
-                ]
-              }
-            }
-          },
-          "oneOf": [
-            {
-              "properties": { "type": { "const": "" } }
-            },
-            {
-              "properties": { "type": { "const": "PEM" } },
-              "required": ["content"]
-            },
-            {
-              "properties": { "type": { "const": "PEM" } },
-              "required": ["path"]
-            },
-            {
-              "properties": { "type": { "pattern": "JKS|PKCS12" } },
-              "required": ["content", "password"]
-            },
-            {
-              "properties": { "type": { "pattern": "JKS|PKCS12" } },
-              "required": ["path", "password"]
-            }
-          ],
-          "x-schema-form": {
-            "hidden": [
-              {
-                "$eq": {
-                  "ssl.trustAll": true
-                }
-              }
-            ]
-          }
-        },
-        "keyStore": {
-          "type": "object",
-          "title": "Key store",
-          "id": "urn:jsonschema:io:gravitee:connector:http:configuration:SslKeyStoreOptions",
-          "properties": {
-            "type": {
-              "type": "string",
-              "title": "Type",
-              "description": "The type of the key store",
-              "default": "",
-              "enum": ["", "JKS", "PKCS12", "PEM"],
-              "x-schema-form": {
-                "type": "select",
-                "titleMap": {
-                  "": "None",
-                  "JKS": "Java Trust Store (.jks)",
-                  "PKCS12": "PKCS#12 (.p12) / PFX (.pfx)",
-                  "PEM": "PEM (.pem)"
-                }
-              }
-            },
-            "password": {
-              "type": "string",
-              "title": "Password",
-              "description": "Key store password",
-              "x-schema-form": {
-                "type": "password",
-                "hidden": [
-                  {
-                    "$eq": {
-                      "ssl.keyStore.type": ["", "PEM"]
-                    }
-                  }
-                ]
-              }
-            },
-            "path": {
-              "type": "string",
-              "title": "Path to key store",
-              "description": "Path to the key store file",
-              "x-schema-form": {
-                "hidden": [
-                  {
-                    "$eq": {
-                      "ssl.keyStore.type": ["", "PEM"]
-                    }
-                  }
-                ]
-              }
-            },
-            "content": {
-              "type": "string",
-              "title": "Content",
-              "description": "Binary content as Base64",
-              "x-schema-form": {
-                "type": "text",
-                "hidden": [
-                  {
-                    "$eq": {
-                      "ssl.keyStore.type": ["", "PEM"]
-                    }
-                  }
-                ]
-              }
-            },
-            "certPath": {
-              "type": "string",
-              "title": "Path to cert file",
-              "description": "Path to cert file (.PEM)",
-              "x-schema-form": {
-                "hidden": [
-                  {
-                    "$neq": {
-                      "ssl.keyStore.type": "PEM"
-                    }
-                  }
-                ]
-              }
-            },
-            "certContent": {
-              "type": "string",
-              "title": "Certificate",
-              "x-schema-form": {
-                "type": "text",
-                "hidden": [
-                  {
-                    "$neq": {
-                      "ssl.keyStore.type": "PEM"
-                    }
-                  }
-                ]
-              }
-            },
-            "keyPath": {
-              "type": "string",
-              "title": "Path to private key file",
-              "description": "Path to private key file (.PEM)",
-              "x-schema-form": {
-                "hidden": [
-                  {
-                    "$neq": {
-                      "ssl.keyStore.type": "PEM"
-                    }
-                  }
-                ]
-              }
-            },
-            "keyContent": {
-              "type": "string",
-              "title": "Private key",
-              "x-schema-form": {
-                "type": "text",
-                "hidden": [
-                  {
-                    "$neq": {
-                      "ssl.keyStore.type": "PEM"
-                    }
-                  }
-                ]
-              }
-            }
-          },
-          "oneOf": [
-            {
-              "properties": { "type": { "const": "" } }
-            },
-            {
-              "properties": { "type": { "const": "PEM" } },
-              "required": ["certContent", "keyContent"]
-            },
-            {
-              "properties": { "type": { "const": "PEM" } },
-              "required": ["certPath", "keyPath"]
-            },
-            {
-              "properties": { "type": { "const": "PEM" } },
-              "required": ["certContent", "keyPath"]
-            },
-            {
-              "properties": { "type": { "const": "PEM" } },
-              "required": ["certPath", "keyContent"]
-            },
-            {
-              "properties": { "type": { "pattern": "JKS|PKCS12" } },
-              "required": ["content", "password"]
-            },
-            {
-              "properties": { "type": { "pattern": "JKS|PKCS12" } },
-              "required": ["path", "password"]
-            }
-          ]
-        }
-      }
     }
-  },
-  "additionalProperties": false,
-  "patternProperties": {
-    "backup": true,
-    "healthcheck": true,
-    "inherit": true,
-    "name": true,
-    "target": true,
-    "tenants": true,
-    "type": true,
-    "weight": true
-  },
-  "x-schema-form": {
-    "errors": {
-      "proxy": {
-        "oneOf": "The host and port are <span class=\"error\">required</span>"
-      },
-      "ssl": {
-        "trustStore": {
-          "oneOf": "A path or a content is <span class=\"error\">required</span> - for JKS and PKCS#12 a password is also <span class=\"error\">required</span>"
-        },
-        "keyStore": {
-          "oneOf": "Paths or contents are <span class=\"error\">required</span> - for JKS and PKCS#12, a password is also <span class=\"error\">required</span>."
-        }
-      }
-    }
-  }
 }

--- a/src/test/java/io/gravitee/connector/http/AbstractHttpConnectorTest.java
+++ b/src/test/java/io/gravitee/connector/http/AbstractHttpConnectorTest.java
@@ -1,11 +1,11 @@
-/**
- * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -22,7 +22,7 @@ import io.gravitee.connector.http.endpoint.HttpEndpoint;
 import io.gravitee.gateway.api.proxy.ProxyRequest;
 import io.gravitee.node.api.configuration.Configuration;
 import io.vertx.core.http.HttpClientOptions;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 class TestHttpConnector extends AbstractHttpConnector<HttpEndpoint> {
 

--- a/src/test/java/io/gravitee/connector/http/HttpConnectionTest.java
+++ b/src/test/java/io/gravitee/connector/http/HttpConnectionTest.java
@@ -1,11 +1,11 @@
-/**
- * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -18,10 +18,6 @@ package io.gravitee.connector.http;
 import static io.gravitee.common.http.HttpHeaders.ACCEPT_ENCODING;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.doThrow;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.spy;
-import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import io.gravitee.common.http.HttpMethod;
@@ -39,18 +35,18 @@ import io.vertx.core.http.HttpClientRequest;
 import java.io.IOException;
 import java.net.ServerSocket;
 import java.util.concurrent.atomic.AtomicInteger;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.Spy;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 /**
  * @author Yann TAVERNIER (yann.tavernier at graviteesource.com)
  * @author GraviteeSource Team
  */
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class HttpConnectionTest {
 
     public static final String FIRST_HEADER = "First-Header";
@@ -77,7 +73,7 @@ public class HttpConnectionTest {
     private HttpHeaders headers;
     private HttpClientOptions httpClientOptions;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         cut = new HttpConnection<>(endpoint, request);
 

--- a/src/test/java/io/gravitee/connector/http/HttpConnectorFactoryTest.java
+++ b/src/test/java/io/gravitee/connector/http/HttpConnectorFactoryTest.java
@@ -1,11 +1,11 @@
-/**
- * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -28,15 +28,12 @@ import io.gravitee.connector.api.ConnectorBuilder;
 import io.gravitee.connector.api.ConnectorContext;
 import io.gravitee.connector.http.grpc.GrpcConnector;
 import io.gravitee.gateway.api.proxy.ProxyRequest;
-import java.util.ArrayList;
-import java.util.List;
 import java.util.Map;
 import java.util.Random;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.atomic.AtomicReference;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 
 public class HttpConnectorFactoryTest {
@@ -47,7 +44,7 @@ public class HttpConnectorFactoryTest {
 
     ConnectorBuilder connectorBuilder;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         connectorBuilder = mock(ConnectorBuilder.class);
         when(connectorBuilder.getMapper()).thenReturn(mapper);
@@ -181,9 +178,7 @@ public class HttpConnectorFactoryTest {
 
         Connector<Connection, ProxyRequest> connector = factory.create(target, configuration, connectorBuilder);
         assertThat(connector).isInstanceOf(HttpConnector.class);
-        assertThat(((HttpConnector) connector).endpoint.getHeaders()).containsExactly(
-            new HttpHeader("X-Gravitee-Api", "test"),
-            new HttpHeader("Empty-Header", "")
-        );
+        assertThat(((HttpConnector) connector).endpoint.getHeaders())
+            .containsExactly(new HttpHeader("X-Gravitee-Api", "test"), new HttpHeader("Empty-Header", ""));
     }
 }

--- a/src/test/java/io/gravitee/connector/http/HttpConnectorTest.java
+++ b/src/test/java/io/gravitee/connector/http/HttpConnectorTest.java
@@ -1,11 +1,11 @@
-/**
- * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -119,9 +119,13 @@ public class HttpConnectorTest {
 
     @Test
     public void shouldOverrideHeaders() {
-        when(endpoint.getHeaders()).thenReturn(
-            Arrays.asList(new HttpHeader(HttpHeaderNames.HOST, "api.gravitee.io"), new HttpHeader(HttpHeaderNames.HOST, "api2.gravitee.io"))
-        );
+        when(endpoint.getHeaders())
+            .thenReturn(
+                Arrays.asList(
+                    new HttpHeader(HttpHeaderNames.HOST, "api.gravitee.io"),
+                    new HttpHeader(HttpHeaderNames.HOST, "api2.gravitee.io")
+                )
+            );
 
         connector.request(executionContext, request, connectionHandler);
 

--- a/src/test/java/io/gravitee/connector/http/grpc/GrpcConnectionTest.java
+++ b/src/test/java/io/gravitee/connector/http/grpc/GrpcConnectionTest.java
@@ -1,11 +1,11 @@
-/**
- * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -80,11 +80,12 @@ public class GrpcConnectionTest {
 
         httpClientOptions = new HttpClientOptions();
         when(endpoint.getHttpClientOptions()).thenReturn(httpClientOptions);
-        when(client.request(any(RequestOptions.class))).thenAnswer(invocation -> {
-            RequestOptions options = invocation.getArgument(0);
-            httpClientRequest = spy(new DummyHttpClientRequest(options));
-            return Future.succeededFuture(httpClientRequest);
-        });
+        when(client.request(any(RequestOptions.class)))
+            .thenAnswer(invocation -> {
+                RequestOptions options = invocation.getArgument(0);
+                httpClientRequest = spy(new DummyHttpClientRequest(options));
+                return Future.succeededFuture(httpClientRequest);
+            });
     }
 
     @Test

--- a/src/test/java/io/gravitee/connector/http/stub/DummyHttpClientRequest.java
+++ b/src/test/java/io/gravitee/connector/http/stub/DummyHttpClientRequest.java
@@ -1,11 +1,11 @@
-/**
- * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -15,6 +15,7 @@
  */
 package io.gravitee.connector.http.stub;
 
+import io.vertx.codegen.annotations.Nullable;
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Future;
 import io.vertx.core.Handler;
@@ -27,6 +28,8 @@ import io.vertx.core.http.HttpVersion;
 import io.vertx.core.http.RequestOptions;
 import io.vertx.core.http.StreamPriority;
 import io.vertx.core.http.impl.headers.HeadersMultiMap;
+import io.vertx.core.net.HostAndPort;
+import java.util.function.Function;
 
 /**
  * Dummy implementation of {@link HttpClientRequest} for testing purpose
@@ -79,6 +82,11 @@ public class DummyHttpClientRequest implements HttpClientRequest {
     }
 
     @Override
+    public HttpClientRequest authority(HostAndPort hostAndPort) {
+        return null;
+    }
+
+    @Override
     public HttpClientRequest setHost(String host) {
         return null;
     }
@@ -104,8 +112,23 @@ public class DummyHttpClientRequest implements HttpClientRequest {
     }
 
     @Override
+    public boolean isFollowRedirects() {
+        return false;
+    }
+
+    @Override
     public HttpClientRequest setMaxRedirects(int maxRedirects) {
         return this;
+    }
+
+    @Override
+    public int getMaxRedirects() {
+        return 0;
+    }
+
+    @Override
+    public int numberOfRedirections() {
+        return 0;
     }
 
     @Override
@@ -184,6 +207,16 @@ public class DummyHttpClientRequest implements HttpClientRequest {
     }
 
     @Override
+    public HttpClientRequest traceOperation(String s) {
+        return null;
+    }
+
+    @Override
+    public String traceOperation() {
+        return null;
+    }
+
+    @Override
     public HttpVersion version() {
         return null;
     }
@@ -206,6 +239,16 @@ public class DummyHttpClientRequest implements HttpClientRequest {
 
     @Override
     public HttpClientRequest continueHandler(Handler<Void> handler) {
+        return null;
+    }
+
+    @Override
+    public HttpClientRequest earlyHintsHandler(@Nullable Handler<MultiMap> handler) {
+        return null;
+    }
+
+    @Override
+    public HttpClientRequest redirectHandler(@Nullable Function<HttpClientResponse, Future<HttpClientRequest>> function) {
         return null;
     }
 

--- a/src/test/java/io/gravitee/connector/http/stub/ThrowingOnGoAwayHttpConnection.java
+++ b/src/test/java/io/gravitee/connector/http/stub/ThrowingOnGoAwayHttpConnection.java
@@ -1,11 +1,11 @@
-/**
- * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/test/java/io/gravitee/connector/http/vertx/VertxHttpHeadersTest.java
+++ b/src/test/java/io/gravitee/connector/http/vertx/VertxHttpHeadersTest.java
@@ -1,11 +1,11 @@
-/**
- * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,


### PR DESCRIPTION

**Issue**

https://gravitee.atlassian.net/browse/APIM-3800

**Description**

BREAKING CHANGE:
This version will only be compatible with APIM 4.4.0 and more due to the fact we rely on the newly introduced gravitee-apim-common. Also bump the dependencies to be aligned with APIM 4.4.0 
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `4.0.0-apim-3800-refactor-vertx-proxy-options-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/connector/gravitee-connector-http/4.0.0-apim-3800-refactor-vertx-proxy-options-SNAPSHOT/gravitee-connector-http-4.0.0-apim-3800-refactor-vertx-proxy-options-SNAPSHOT.zip)
  <!-- Version placeholder end -->
