### PR TITLE
fix: ensure httpClientRequest is not null when there is request content

### DIFF
--- a/src/main/java/io/gravitee/connector/http/HttpConnection.java
+++ b/src/main/java/io/gravitee/connector/http/HttpConnection.java
@@ -273,13 +273,14 @@ public class HttpConnection<T extends HttpResponse> extends AbstractHttpConnecti
     public HttpConnection<T> write(Buffer chunk) {
         // There is some request content, set the flag to true
         content = true;
+        // Request can be null in case of connectivity issue with the upstream
+        if (httpClientRequest != null) {
+            if (!headersWritten) {
+                this.writeHeaders();
+            }
 
-        if (!headersWritten) {
-            this.writeHeaders();
+            httpClientRequest.write(io.vertx.core.buffer.Buffer.buffer(chunk.getNativeBuffer()));
         }
-
-        httpClientRequest.write(io.vertx.core.buffer.Buffer.buffer(chunk.getNativeBuffer()));
-
         return this;
     }
 
@@ -291,7 +292,11 @@ public class HttpConnection<T extends HttpResponse> extends AbstractHttpConnecti
 
     @Override
     public boolean writeQueueFull() {
-        return httpClientRequest.writeQueueFull();
+        // Request can be null in case of connectivity issue with the upstream
+        if (httpClientRequest != null) {
+            return httpClientRequest.writeQueueFull();
+        }
+        return false;
     }
 
     private void writeHeaders() {


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-4986

## Description

ensure httpClientRequest is not null when there is request content

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `3.1.2-APIM-4986-client-request-npe-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/connector/gravitee-connector-http/3.1.2-APIM-4986-client-request-npe-SNAPSHOT/gravitee-connector-http-3.1.2-APIM-4986-client-request-npe-SNAPSHOT.zip)
  <!-- Version placeholder end -->
