### PR TITLE
Fix HTTP upgrade bug on GET request - 3.1.x

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -107,6 +107,12 @@
 
         <!-- test dependencies -->
         <dependency>
+            <groupId>io.gravitee.apim.gateway</groupId>
+            <artifactId>gravitee-apim-gateway-buffer</artifactId>
+            <version>4.0.25</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <scope>test</scope>

--- a/src/main/java/io/gravitee/connector/http/HttpConnection.java
+++ b/src/main/java/io/gravitee/connector/http/HttpConnection.java
@@ -279,6 +279,18 @@ public class HttpConnection<T extends HttpResponse> extends AbstractHttpConnecti
                 this.writeHeaders();
             }
 
+            /*
+            When the http connection is upgraded from http1.1 to http2, an empty body is sent, even if the request is a GET.
+            And in a GET request the CONTENT-LENGTH header does not exist.
+            To avoid any issue in that specific situation, CONTENT-LENGTH header is set to 0.
+             */
+            HttpHeaders headers = request.headers();
+            if (
+                chunk.length() == 0 && (headers == null || !headers.contains(io.gravitee.gateway.api.http.HttpHeaderNames.CONTENT_LENGTH))
+            ) {
+                httpClientRequest.headers().set(io.gravitee.gateway.api.http.HttpHeaderNames.CONTENT_LENGTH, "0");
+            }
+
             httpClientRequest.write(io.vertx.core.buffer.Buffer.buffer(chunk.getNativeBuffer()));
         }
         return this;

--- a/src/test/java/io/gravitee/connector/http/HttpConnectionTest.java
+++ b/src/test/java/io/gravitee/connector/http/HttpConnectionTest.java
@@ -16,6 +16,7 @@
 package io.gravitee.connector.http;
 
 import static io.gravitee.common.http.HttpHeaders.ACCEPT_ENCODING;
+import static io.gravitee.common.http.HttpHeaders.CONTENT_LENGTH;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doThrow;
@@ -119,6 +120,14 @@ public class HttpConnectionTest {
         assertThat(httpClientRequest.headers().getAll(SECOND_HEADER)).hasSize(1).containsExactly(SECOND_HEADER_VALUE);
 
         assertThat(httpClientRequest.headers().getAll(FIRST_HEADER)).hasSize(2).containsExactly(FIRST_HEADER_VALUE_1, FIRST_HEADER_VALUE_2);
+    }
+
+    @Test
+    public void shouldWrite() {
+        cut.connect(client, getAvailablePort(), "host", "/", unused -> {}, result -> new AtomicInteger(1).decrementAndGet());
+        assertThat(httpClientRequest.headers().get(CONTENT_LENGTH)).isNull();
+        cut.write(io.gravitee.gateway.api.buffer.Buffer.buffer());
+        assertThat(httpClientRequest.headers().get(CONTENT_LENGTH)).isEqualTo("0");
     }
 
     @Test


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-5231
https://github.com/gravitee-io/issues/issues/9757

## Description

When the http connection is upgraded from http1.1 to http2, an empty body is sent, even if the request is a GET.
And in a GET request the CONTENT-LENGTH header does not exist, we must set it to 0.

<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `3.1.3-apim-5231-fix-http-upgrade-on-get-request-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/connector/gravitee-connector-http/3.1.3-apim-5231-fix-http-upgrade-on-get-request-SNAPSHOT/gravitee-connector-http-3.1.3-apim-5231-fix-http-upgrade-on-get-request-SNAPSHOT.zip)
  <!-- Version placeholder end -->
