### PR TITLE
fix: pause the endpoint request when upgrading

### DIFF
--- a/src/main/java/io/gravitee/connector/http/ws/WebSocketConnection.java
+++ b/src/main/java/io/gravitee/connector/http/ws/WebSocketConnection.java
@@ -82,6 +82,7 @@ public class WebSocketConnection extends AbstractHttpConnection<HttpEndpoint> {
             options,
             event -> {
                 if (event.succeeded()) {
+                    event.result().pause();
                     // The client -> gateway connection must be upgraded now that the one between gateway -> upstream
                     // has been accepted
                     wsProxyRequest
@@ -154,6 +155,8 @@ public class WebSocketConnection extends AbstractHttpConnection<HttpEndpoint> {
 
                             // Tell the reactor that the request has been handled by the HTTP client
                             sendToClient(new SwitchProtocolProxyResponse());
+
+                            event.result().resume();
                         });
                 } else {
                     connectionHandler.handle(null);


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-5257

## Description

with the current implementation we miss the first “connection” frame sent by socket.io server, the solution is to pause the endpoint request when upgrading the client request, link them together then resume the endpoint websocket.

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `4.0.2-APIM-5257-socketio-master-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/connector/gravitee-connector-http/4.0.2-APIM-5257-socketio-master-SNAPSHOT/gravitee-connector-http-4.0.2-APIM-5257-socketio-master-SNAPSHOT.zip)
  <!-- Version placeholder end -->
