### PR TITLE
fix: avoid some NPE when connection has failed

### DIFF
--- a/src/main/java/io/gravitee/connector/http/AbstractHttpConnection.java
+++ b/src/main/java/io/gravitee/connector/http/AbstractHttpConnection.java
@@ -42,6 +42,8 @@ public abstract class AbstractHttpConnection<E extends HttpEndpoint> extends io.
     );
 
     protected void sendToClient(Response response) {
-        this.responseHandler.handle(response);
+        if (this.responseHandler != null) {
+            this.responseHandler.handle(response);
+        }
     }
 }

--- a/src/main/java/io/gravitee/connector/http/HttpConnection.java
+++ b/src/main/java/io/gravitee/connector/http/HttpConnection.java
@@ -235,8 +235,12 @@ public class HttpConnection<T extends HttpResponse> extends AbstractHttpConnecti
     @Override
     public Connection cancel() {
         this.canceled = true;
-        this.httpClientRequest.reset();
-        cancelHandler.handle(null);
+        if (this.httpClientRequest != null) {
+            this.httpClientRequest.reset();
+        }
+        if (cancelHandler != null) {
+            cancelHandler.handle(null);
+        }
         if (response != null) {
             response.bodyHandler(null);
         }
@@ -264,7 +268,9 @@ public class HttpConnection<T extends HttpResponse> extends AbstractHttpConnecti
     }
 
     private void handleConnectTimeout(Throwable throwable) {
-        this.timeoutHandler.handle(throwable);
+        if (this.timeoutHandler != null) {
+            this.timeoutHandler.handle(throwable);
+        }
     }
 
     private Handler<Throwable> timeoutHandler() {
@@ -300,7 +306,13 @@ public class HttpConnection<T extends HttpResponse> extends AbstractHttpConnecti
 
     @Override
     public WriteStream<Buffer> drainHandler(Handler<Void> drainHandler) {
-        httpClientRequest.drainHandler(aVoid -> drainHandler.handle(null));
+        if (this.httpClientRequest != null) {
+            httpClientRequest.drainHandler(aVoid -> {
+                if (this.timeoutHandler != null) {
+                    drainHandler.handle(null);
+                }
+            });
+        }
         return this;
     }
 
@@ -358,11 +370,13 @@ public class HttpConnection<T extends HttpResponse> extends AbstractHttpConnecti
 
     @Override
     public Connection writeCustomFrame(HttpFrame frame) {
-        httpClientRequest.writeCustomFrame(
-            frame.type(),
-            frame.flags(),
-            io.vertx.core.buffer.Buffer.buffer(frame.payload().getNativeBuffer())
-        );
+        if (httpClientRequest != null) {
+            httpClientRequest.writeCustomFrame(
+                frame.type(),
+                frame.flags(),
+                io.vertx.core.buffer.Buffer.buffer(frame.payload().getNativeBuffer())
+            );
+        }
 
         return this;
     }


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/ARCHI-445

## Description

When testing shadowing policy, it appears that some NPE could occur when there are errors on the shadow connection.

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

