### PR TITLE
fix: avoid some NPE when connection has failed

### DIFF
--- a/src/main/java/io/gravitee/connector/http/AbstractHttpConnection.java
+++ b/src/main/java/io/gravitee/connector/http/AbstractHttpConnection.java
@@ -44,6 +44,8 @@ public abstract class AbstractHttpConnection<E extends HttpEndpoint> extends io.
     );
 
     protected void sendToClient(Response response) {
-        this.responseHandler.handle(response);
+        if (this.responseHandler != null) {
+            this.responseHandler.handle(response);
+        }
     }
 }


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-8046

## Description

cherry pick from https://github.com/gravitee-io/gravitee-connector-http/pull/87

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `5.0.0-APIM8046-alpha-cherry-pick-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/connector/gravitee-connector-http/5.0.0-APIM8046-alpha-cherry-pick-SNAPSHOT/gravitee-connector-http-5.0.0-APIM8046-alpha-cherry-pick-SNAPSHOT.zip)
  <!-- Version placeholder end -->
