### PR TITLE
fix: set SSL for https requests only

### DIFF
--- a/src/main/java/io/gravitee/connector/http/HttpConnection.java
+++ b/src/main/java/io/gravitee/connector/http/HttpConnection.java
@@ -36,11 +36,7 @@ import io.netty.handler.codec.http.HttpHeaderNames;
 import io.netty.handler.codec.http.HttpHeaderValues;
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Future;
-import io.vertx.core.http.HttpClient;
-import io.vertx.core.http.HttpClientRequest;
-import io.vertx.core.http.HttpClientResponse;
-import io.vertx.core.http.HttpMethod;
-import io.vertx.core.http.RequestOptions;
+import io.vertx.core.http.*;
 import java.net.ConnectException;
 import java.net.NoRouteToHostException;
 import java.net.UnknownHostException;
@@ -187,6 +183,7 @@ public class HttpConnection<T extends HttpResponse> extends AbstractHttpConnecti
             .setMethod(HttpMethod.valueOf(request.method().name()))
             .setPort(port)
             .setURI(uri)
+            .setSsl(request.uri().split(":")[0].equalsIgnoreCase("https"))
             .setTimeout(endpoint.getHttpClientOptions().getReadTimeout())
             .setFollowRedirects(endpoint.getHttpClientOptions().isFollowRedirects());
     }

--- a/src/test/java/io/gravitee/connector/http/HttpConnectionTest.java
+++ b/src/test/java/io/gravitee/connector/http/HttpConnectionTest.java
@@ -19,7 +19,6 @@ import static io.gravitee.common.http.HttpHeaders.ACCEPT_ENCODING;
 import static io.gravitee.common.http.HttpHeaders.CONTENT_LENGTH;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import io.gravitee.common.http.HttpMethod;
@@ -98,6 +97,7 @@ public class HttpConnectionTest {
         when(endpoint.getHttpClientOptions()).thenReturn(httpClientOptions);
         when(client.request(any())).thenReturn(Future.succeededFuture(httpClientRequest));
         when(context.getTracer()).thenReturn(new Tracer(null, new NoOpTracer()));
+        when(request.uri()).thenReturn("http://host.fr");
     }
 
     @Test


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-8304

## Description

Create SSL connection for https requests only.

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

