### PR TITLE
fix: remove graceful shutdown on stop http connector

### DIFF
--- a/src/main/java/io/gravitee/connector/http/AbstractHttpConnector.java
+++ b/src/main/java/io/gravitee/connector/http/AbstractHttpConnector.java
@@ -343,17 +343,11 @@ public abstract class AbstractHttpConnector<E extends HttpEndpoint> extends Abst
     @Override
     protected void doStop() throws Exception {
         LOGGER.debug(
-            "Graceful shutdown of HTTP Client for endpoint[{}] target[{}] requests[{}]",
+            "Shutdown of HTTP Client for endpoint[{}] target[{}] requests[{}]",
             endpoint.name(),
             endpoint.target(),
             requestTracker.get()
         );
-
-        long shouldEndAt = System.currentTimeMillis() + endpoint.getHttpClientOptions().getReadTimeout();
-
-        while (requestTracker.get() > 0 && System.currentTimeMillis() <= shouldEndAt) {
-            TimeUnit.MILLISECONDS.sleep(100);
-        }
 
         if (requestTracker.get() > 0) {
             LOGGER.warn("Cancel requests[{}] for endpoint[{}] target[{}]", requestTracker.get(), endpoint.name(), endpoint.target());


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-8624

## Description

When we deploy APi during active requests with long read timeout we could block entire Gateway by blocking vert.x-eventloop-thread.
graceful stop is made by the API reactor which tracks the pending requests and apply a graceful delay base on a global gateway config (e.g. api.pending_requests_timeout: 10000)

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `5.0.3-APIM-8624-onstop5-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/connector/gravitee-connector-http/5.0.3-APIM-8624-onstop5-SNAPSHOT/gravitee-connector-http-5.0.3-APIM-8624-onstop5-SNAPSHOT.zip)
  <!-- Version placeholder end -->
