### PR TITLE
fix: changed reference 'event' to 'exEvent'

### DIFF
--- a/src/main/java/io/gravitee/connector/http/HttpConnection.java
+++ b/src/main/java/io/gravitee/connector/http/HttpConnection.java
@@ -137,9 +137,9 @@ public class HttpConnection<T extends HttpResponse> extends AbstractHttpConnecti
                     });
 
                 httpClientRequest.exceptionHandler(exEvent -> {
-                    ctx.getTracer().endOnError(requestSpan, event.cause());
+                    ctx.getTracer().endOnError(requestSpan, exEvent.getCause());
                     if (!isCanceled() && !isTransmitted()) {
-                        handleException(event.cause());
+                        handleException(exEvent.getCause());
                         tracker.handle(null);
                     }
                 });


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-9142

## Description

changed reference 'event' to 'exEvent'
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `5.0.4-APIM-9142-Bug-in-HttpConnection-exceptionHandlerMaster-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/connector/gravitee-connector-http/5.0.4-APIM-9142-Bug-in-HttpConnection-exceptionHandlerMaster-SNAPSHOT/gravitee-connector-http-5.0.4-APIM-9142-Bug-in-HttpConnection-exceptionHandlerMaster-SNAPSHOT.zip)
  <!-- Version placeholder end -->
