### PR TITLE
fix: check if response endHandler is not null before invoking it

### DIFF
--- a/src/main/java/io/gravitee/connector/http/HttpConnection.java
+++ b/src/main/java/io/gravitee/connector/http/HttpConnection.java
@@ -215,7 +215,10 @@ public class HttpConnection<T extends HttpResponse> extends AbstractHttpConnecti
                     throwable.getMessage()
                 );
 
-                response.endHandler().handle(null);
+                if (response.endHandler() != null) {
+                    response.endHandler().handle(null);
+                }
+
                 tracker.handle(null);
             });
 


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-9685

## Description

This PR avoid an exception linked to this PR https://github.com/gravitee-io/gravitee-api-management/pull/11860
There is some case where the response could have been released before and this causes an NPE.

(cherry picked from commit 4f2d0607bd5aa2ae1fc634a2c923fa0fb9c24cc2)
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `4.0.9-fix-npe-response-endhandler-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/connector/gravitee-connector-http/4.0.9-fix-npe-response-endhandler-SNAPSHOT/gravitee-connector-http-4.0.9-fix-npe-response-endhandler-SNAPSHOT.zip)
  <!-- Version placeholder end -->
