### PR TITLE
fix: use a released version of APIM

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,7 @@
     <name>Gravitee.io - Connector - HTTP</name>
 
     <properties>
-        <gravitee-apim.version>4.12.0-SNAPSHOT</gravitee-apim.version>
+        <gravitee-apim.version>4.10.9</gravitee-apim.version>
 
         <!-- Need to override the version to build a version so APIM can be updated with it -->
         <!-- Will be removed once APIM version is built -->


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-XXX

## Description

Fix the APIM version used to avoid not being deployed on maven repo.

<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `6.0.0-fix-use-released-apim-version-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/connector/gravitee-connector-http/6.0.0-fix-use-released-apim-version-SNAPSHOT/gravitee-connector-http-6.0.0-fix-use-released-apim-version-SNAPSHOT.zip)
  <!-- Version placeholder end -->
